### PR TITLE
Add l2cap reconnection support on script part. Only Linux native part imlemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Peripheral disconnect or cancel pending connection:
 
     peripheral.disconnect([callback(error)]);
 
+Peripheral reconnect connection:
+
+    peripheral.reconnect([callback(error)]);
+
 Peripheral update RSSI
 
     peripheral.updateRssi([callback(error, rssi)]);
@@ -160,6 +164,14 @@ Peripheral connected:
 Peripheral disconnected:
 
     peripheral.on('disconnect', callback);
+    
+Peripheral reconnected:
+
+    peripheral.on('reconnect', callback);
+    
+Peripheral connection drop:
+
+    peripheral.on('connectionDrop', callback);    
 
 Peripheral RSSI update
 

--- a/lib/linux/bindings.js
+++ b/lib/linux/bindings.js
@@ -77,6 +77,8 @@ nobleBindings.connect = function(peripheralUuid) {
   this._l2capBle[address] = new L2capBle(address, addressType);
   this._l2capBle[address].on('connect', this.onConnect.bind(this));
   this._l2capBle[address].on('disconnect', this.onDisconnect.bind(this));
+  this._l2capBle[address].on('connectionDrop', this.onConnectionDrop.bind(this));  
+  this._l2capBle[address].on('reconnect', this.onReconnect.bind(this)); 
   this._l2capBle[address].on('mtu', this.onMtu.bind(this));
   this._l2capBle[address].on('rssi', this.onRssi.bind(this));
   this._l2capBle[address].on('servicesDiscover', this.onServicesDiscovered.bind(this));
@@ -113,6 +115,11 @@ nobleBindings.disconnect = function(peripheralUuid) {
   this._l2capBle[address].disconnect();
 };
 
+nobleBindings.reconnect = function(peripheralUuid) {
+  var address = this._addresses[peripheralUuid];
+  this._l2capBle[address].reconnect();
+};
+
 nobleBindings.onDisconnect = function(address) {
   var uuid = address.split(':').join('').toLowerCase();
 
@@ -123,6 +130,16 @@ nobleBindings.onDisconnect = function(address) {
   delete this._l2capBle[address];
 
   this.emit('disconnect', uuid);
+};
+
+nobleBindings.onConnectionDrop = function(address) {
+  var uuid = address.split(':').join('').toLowerCase();
+  this.emit('connectionDrop', uuid);
+};
+
+nobleBindings.onReconnect = function(address) {
+  var uuid = address.split(':').join('').toLowerCase();
+  this.emit('reconnect', uuid);
 };
 
 nobleBindings.exchangeMtu = function(peripheralUuid, mtu) {

--- a/lib/linux/l2cap-ble.js
+++ b/lib/linux/l2cap-ble.js
@@ -51,6 +51,9 @@ var GATT_CHARAC_UUID                = 0x2803;
 var GATT_CLIENT_CHARAC_CFG_UUID     = 0x2902;
 var GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
 
+//Connect parameter given to l2cap child process
+var L2capConnectType = Object.freeze({CONNECT : 1, RECONNECT : 2});
+
 var L2capBle = function(address, addressType) {
   this._address = address;
   this._addressType = addressType;
@@ -97,7 +100,14 @@ L2capBle.prototype.onStdoutData = function(data) {
       this.emit('connect', this._address, error);
     } else if ((found = line.match(/^disconnect$/))) {
       this.emit('disconnect', this._address);
-    } else if ((found = line.match(/^rssi = (.*)$/))) {
+    }else if ((found = line.match(/^connectionDrop = (.*)$/))) {
+      debug(this._address + ': connection drop, error = ' + line.split(' = ')[1]);
+      this.emit('connectionDrop', this._address);
+      return;     
+    }else if ((found = line.match(/^reconnect (.*)$/))) {
+      debug(this._address + ': reconnect');
+      this.emit('reconnect', this._address);
+    }else if ((found = line.match(/^rssi = (.*)$/))) {
       var rssi = parseInt(found[1], 10);
 
       this.emit('rssi', this._address, rssi);
@@ -173,18 +183,27 @@ L2capBle.prototype.onStderrData = function(data) {
   console.error(this._address + ': stderr: ' + data);
 };
 
-L2capBle.prototype.connect = function() {
+L2capBle.prototype.connect = function(connectType) {
+  if(typeof(connectType) === 'undefined') connectType = L2capConnectType.CONNECT;
+  
   var l2capBle = __dirname + '/../../build/Release/l2cap-ble';
   
   debug(this._address + ': l2capBle = ' + l2capBle);
-
-  this._l2capBle = spawn(l2capBle, [this._address, this._addressType]);
+  this._l2capBle = spawn(l2capBle, [this._address, this._addressType, connectType]);
   this._l2capBle.on('close', this.onClose.bind(this));
   this._l2capBle.stdout.on('data', this.onStdoutData.bind(this));
   this._l2capBle.stdin.on('error', this.onStdinError.bind(this));
   this._l2capBle.stderr.on('data', this.onStderrData.bind(this));
 
   this._buffer = "";
+  this._currentCommand = null;
+  this._commandQueue = [];
+};
+
+L2capBle.prototype.reconnect = function() {
+	//Be sure l2cap disconnected
+	this.disconnect();
+	this.connect(L2capConnectType.RECONNECT);
 };
 
 L2capBle.prototype.disconnect = function() {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -38,6 +38,8 @@ function Noble() {
   this._bindings.on('discover', this.onDiscover.bind(this));
   this._bindings.on('connect', this.onConnect.bind(this));
   this._bindings.on('disconnect', this.onDisconnect.bind(this));
+  this._bindings.on('connectionDrop', this.onConnectionDrop.bind(this));
+  this._bindings.on('reconnect', this.onReconnect.bind(this));
   this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
   this._bindings.on('servicesDiscover', this.onServicesDiscover.bind(this));
   this._bindings.on('includedServicesDiscover', this.onIncludedServicesDiscover.bind(this));
@@ -143,6 +145,10 @@ Noble.prototype.disconnect = function(peripheralUuid) {
   this._bindings.disconnect(peripheralUuid);
 };
 
+Noble.prototype.reconnect = function(peripheralUuid) {
+  this._bindings.reconnect(peripheralUuid);
+};
+
 Noble.prototype.onDisconnect = function(peripheralUuid) {
   var peripheral = this._peripherals[peripheralUuid];
 
@@ -151,6 +157,28 @@ Noble.prototype.onDisconnect = function(peripheralUuid) {
     peripheral.emit('disconnect');
   } else {
     console.warn('noble: unknown peripheral ' + peripheralUuid + ' disconnected!');
+  }
+};
+
+Noble.prototype.onConnectionDrop = function(peripheralUuid) {
+  var peripheral = this._peripherals[peripheralUuid];
+
+  if (peripheral) {
+    peripheral.state = 'disconnected';
+    peripheral.emit('connectionDrop');
+  } else {
+    console.warn('noble: unknown peripheral ' + peripheralUuid + ' lost connection!');
+  }
+};
+
+Noble.prototype.onReconnect = function(peripheralUuid) {
+  var peripheral = this._peripherals[peripheralUuid];
+  
+  if (peripheral) {
+    peripheral.state = 'connected';
+    peripheral.emit('reconnect');
+  } else {
+    console.warn('noble: unknown peripheral ' + peripheralUuid + ' reconnected');
   }
 };
 

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -50,6 +50,16 @@ Peripheral.prototype.disconnect = function(callback) {
   this._noble.disconnect(this.uuid);
 };
 
+Peripheral.prototype.reconnect = function(callback) {
+  if (callback) {
+    this.once('reconnect', function() {
+      callback(null);
+    });
+  }
+  this.state = 'reconnecting';
+  this._noble.reconnect(this.uuid);
+};
+
 Peripheral.prototype.updateRssi = function(callback) {
   if (callback) {
     this.once('rssiUpdate', function(rssi) {

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -71,7 +71,11 @@ Peripheral.prototype.updateRssi = function(callback) {
 };
 
 Peripheral.prototype.discoverServices = function(uuids, callback) {
-  if (callback) {
+  if (callback) {  
+    //Take care about once() when reconnecting - after a reconnection 
+    //callback will be called twice. In events implementation same listener
+    //can be added twice. To prevent this remove pending listeners befor calling once
+    this.removeAllListeners('servicesDiscover');
     this.once('servicesDiscover', function(services) {
       callback(null, services);
     });
@@ -81,7 +85,9 @@ Peripheral.prototype.discoverServices = function(uuids, callback) {
 };
 
 Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUuids, characteristicsUuids, callback) {
-  this.discoverServices(serviceUuids, function(err, services) {
+    this.discoverServices(serviceUuids, function(err, services) {
+    
+    
     var numDiscovered = 0;
     var allCharacteristics = [];
 

--- a/src/l2cap-ble.c
+++ b/src/l2cap-ble.c
@@ -8,115 +8,186 @@
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
 
+
+
+/***************************************************
+ *   MACROS
+ **************************************************/
 #define ATT_CID 4
 
 #define BDADDR_LE_PUBLIC       0x01
 #define BDADDR_LE_RANDOM       0x02
 
-struct sockaddr_l2 {
-  sa_family_t    l2_family;
-  unsigned short l2_psm;
-  bdaddr_t       l2_bdaddr;
-  unsigned short l2_cid;
-  uint8_t        l2_bdaddr_type;
-};
-
 #define L2CAP_CONNINFO  0x02
+
+#if !defined(NB_CONNECTION_TRIES)
+#define NB_CONNECTION_TRIES 5
+#endif
+
+/***************************************************
+ *   Private variables
+ **************************************************/
+static int l2capSock;
+static int hciHandle;
+static int lastSignal = 0;
+
+/***************************************************
+ *   Private types
+ **************************************************/
 struct l2cap_conninfo {
-  uint16_t       hci_handle;
-  uint8_t        dev_class[3];
+	uint16_t       hci_handle;
+	uint8_t        dev_class[3];
 };
 
-int lastSignal = 0;
+struct sockaddr_l2 {
+	sa_family_t    l2_family;
+	unsigned short l2_psm;
+	bdaddr_t       l2_bdaddr;
+	unsigned short l2_cid;
+	uint8_t        l2_bdaddr_type;
+};
+
+typedef enum{
+	CONNECT_ARG = 1,
+	RECONNECT_ARG = 2
+}EPProcessConnectArg;
+
+/***************************************************
+ *   Private types
+ **************************************************/
+static void signalHandler(int signal);
+static int connectL2Cap(const char* arg_raw_bt_address, const char* arg_bt_address_type, int arg_nb_tries);
+
+
 
 static void signalHandler(int signal) {
   lastSignal = signal;
 }
 
+/**
+ * Connect L2cap socket to given device
+ * @param arg_raw_bt_address
+ * @param arg_bt_address_type
+ * @param arg_nb_tries number of attempts
+ * @return 0 if successful, error code otherwise
+ */
+static int connectL2Cap(const char* arg_raw_bt_address, const char* arg_bt_address_type, int arg_nb_tries)
+{
+	int nb_tries = 0;
+	int result;
+	struct sockaddr_l2 sockAddr;
+	struct l2cap_conninfo l2capConnInfo;
+	socklen_t l2capConnInfoLen;
+
+	// create socket
+	l2capSock = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+
+	// bind
+	memset(&sockAddr, 0, sizeof(sockAddr));
+	sockAddr.l2_family = AF_BLUETOOTH;
+	bacpy(&sockAddr.l2_bdaddr, BDADDR_ANY);
+	sockAddr.l2_cid = htobs(ATT_CID);
+
+	result = bind(l2capSock, (struct sockaddr*)&sockAddr, sizeof(sockAddr));
+
+	printf("bind %s\n", (result == -1) ? strerror(errno) : "success");
+
+	// connect
+	memset(&sockAddr, 0, sizeof(sockAddr));
+	sockAddr.l2_family = AF_BLUETOOTH;
+	str2ba(arg_raw_bt_address, &sockAddr.l2_bdaddr);
+	sockAddr.l2_bdaddr_type = strcmp(arg_bt_address_type, "random") == 0 ? BDADDR_LE_RANDOM : BDADDR_LE_PUBLIC;
+	sockAddr.l2_cid = htobs(ATT_CID);
+
+	result = -1;
+	while(nb_tries < arg_nb_tries && result == -1)
+	{
+		result = connect(l2capSock, (struct sockaddr *)&sockAddr, sizeof(sockAddr));
+		nb_tries ++;
+		sleep(1);
+	}
+
+	if(result >= 0)
+	{
+		l2capConnInfoLen = sizeof(l2capConnInfo);
+		getsockopt(l2capSock, SOL_L2CAP, L2CAP_CONNINFO, &l2capConnInfo, &l2capConnInfoLen);
+		hciHandle = l2capConnInfo.hci_handle;
+	}
+	else
+	{
+		//Connection failed
+	}
+	return result;
+}
+
 int main(int argc, const char* argv[]) {
-  char *hciDeviceIdOverride = NULL;
-  int hciDeviceId = 0;
-  int hciSocket;
+	char *hciDeviceIdOverride = NULL;
+	int hciDeviceId = 0;
+	int hciSocket;
+	int result;
 
-  int l2capSock;
-  struct sockaddr_l2 sockAddr;
-  struct l2cap_conninfo l2capConnInfo;
-  socklen_t l2capConnInfoLen;
-  int hciHandle;
-  int result;
+	fd_set rfds;
+	struct timeval tv;
 
-  fd_set rfds;
-  struct timeval tv;
+	char stdinBuf[256 * 2 + 1];
+	char l2capSockBuf[256];
+	int len;
+	int i;
+	unsigned int data;
 
-  char stdinBuf[256 * 2 + 1];
-  char l2capSockBuf[256];
-  int len;
-  int i;
-  unsigned int data;
+	// setup signal handlers
+	signal(SIGINT, signalHandler);
+	signal(SIGKILL, signalHandler);
+	signal(SIGHUP, signalHandler);
+	signal(SIGUSR1, signalHandler);
+	signal(SIGUSR2, signalHandler);
 
-  // setup signal handlers
-  signal(SIGINT, signalHandler);
-  signal(SIGKILL, signalHandler);
-  signal(SIGHUP, signalHandler);
-  signal(SIGUSR1, signalHandler);
-  signal(SIGUSR2, signalHandler);
+	prctl(PR_SET_PDEATHSIG, SIGINT);
 
-  prctl(PR_SET_PDEATHSIG, SIGINT);
+	// remove buffering
+	setbuf(stdin, NULL);
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
 
-  // remove buffering 
-  setbuf(stdin, NULL);
-  setbuf(stdout, NULL);
-  setbuf(stderr, NULL);
+	hciDeviceIdOverride = getenv("NOBLE_HCI_DEVICE_ID");
+	if (hciDeviceIdOverride != NULL) {
+		hciDeviceId = atoi(hciDeviceIdOverride);
+	} else {
+		// if no env variable given, use the first available device
+		hciDeviceId = hci_get_route(NULL);
+	}
 
-  hciDeviceIdOverride = getenv("NOBLE_HCI_DEVICE_ID");
-  if (hciDeviceIdOverride != NULL) {
-    hciDeviceId = atoi(hciDeviceIdOverride);
-  } else {
-    // if no env variable given, use the first available device
-    hciDeviceId = hci_get_route(NULL);
-  }
+	if (hciDeviceId < 0) {
+		hciDeviceId = 0; // use device 0, if device id is invalid
+	}
 
-  if (hciDeviceId < 0) {
-    hciDeviceId = 0; // use device 0, if device id is invalid
-  }
+	hciSocket = hci_open_dev(hciDeviceId);
 
-  hciSocket = hci_open_dev(hciDeviceId);
+	/* Try a connection */
+	result = connectL2Cap(argv[1], argv[2], NB_CONNECTION_TRIES);
 
-  // create socket
-  l2capSock = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+	if(result >= 0)
+	{
+		if(atoi(argv[3]) == RECONNECT_ARG)
+		{
+			printf("reconnect %s\n", (result < 0) ? strerror(errno) : "success");
+		}
+		else //CONNECT_ARG
+		{
+			printf("connect %s\n", (result < 0) ? strerror(errno) : "success");
+		}
+	}
+	else
+	{
+		//Connection failed
+		printf("disconnect\n");
+		goto done;
+	}
 
-  // bind
-  memset(&sockAddr, 0, sizeof(sockAddr));
-  sockAddr.l2_family = AF_BLUETOOTH;
-  bacpy(&sockAddr.l2_bdaddr, BDADDR_ANY);
-  sockAddr.l2_cid = htobs(ATT_CID);
 
-  result = bind(l2capSock, (struct sockaddr*)&sockAddr, sizeof(sockAddr));
-
-  printf("bind %s\n", (result == -1) ? strerror(errno) : "success");
-
-  // connect
-  memset(&sockAddr, 0, sizeof(sockAddr));
-  sockAddr.l2_family = AF_BLUETOOTH;
-  str2ba(argv[1], &sockAddr.l2_bdaddr);
-  sockAddr.l2_bdaddr_type = strcmp(argv[2], "random") == 0 ? BDADDR_LE_RANDOM : BDADDR_LE_PUBLIC;
-  sockAddr.l2_cid = htobs(ATT_CID);
-
-  result = connect(l2capSock, (struct sockaddr *)&sockAddr, sizeof(sockAddr));
-
-  l2capConnInfoLen = sizeof(l2capConnInfo);
-  getsockopt(l2capSock, SOL_L2CAP, L2CAP_CONNINFO, &l2capConnInfo, &l2capConnInfoLen);
-  hciHandle = l2capConnInfo.hci_handle;
-
-  printf("connect %s\n", (result == -1) ? strerror(errno) : "success");
-
-  if (result == -1) {
-    goto done;
-  }
-
-  while(1) {
+	while(1) {
     FD_ZERO(&rfds);
-    FD_SET(0, &rfds);
+    FD_SET(STDIN_FILENO, &rfds);
     FD_SET(l2capSock, &rfds);
 
     tv.tv_sec = 1;
@@ -126,6 +197,7 @@ int main(int argc, const char* argv[]) {
 
     if (-1 == result) {
       if (SIGINT == lastSignal || SIGKILL == lastSignal || SIGHUP == lastSignal) {
+    	printf("disconnect\n");
         break;
       }
 
@@ -159,45 +231,45 @@ int main(int argc, const char* argv[]) {
         printf("security = %s\n", (BT_SECURITY_MEDIUM == btSecurity.level) ? "medium" : "low");
       }
     } else if (result) {
-      if (FD_ISSET(0, &rfds)) {
-        len = read(0, stdinBuf, sizeof(stdinBuf));
+      if (FD_ISSET(STDIN_FILENO, &rfds)) {
+        len = read(STDIN_FILENO, stdinBuf, sizeof(stdinBuf));
 
         if (len <= 0) {
+          printf("disconnect\n");
           break;
         }
 
         i = 0;
         while(stdinBuf[i] != '\n') {
           sscanf(&stdinBuf[i], "%02x", &data);
-
           l2capSockBuf[i / 2] = data;
-
           i += 2;
         }
-
         len = write(l2capSock, l2capSockBuf, (len - 1) / 2);
       }
 
       if (FD_ISSET(l2capSock, &rfds)) {
-        len = read(l2capSock, l2capSockBuf, sizeof(l2capSockBuf));
+			len = read(l2capSock, l2capSockBuf, sizeof(l2capSockBuf));
 
-        if (len <= 0) {
-          break;
-        }
-
-        printf("data ");
-        for(i = 0; i < len; i++) {
-          printf("%02x", ((int)l2capSockBuf[i]) & 0xff);
-        }
-        printf("\n");
-      }
+			/** Connection lost */
+			if (len <= 0) {
+				printf("connectionDrop = %s\n", strerror(errno));
+				break;
+			}
+			else
+			{
+				printf("data ");
+				for(i = 0; i < len; i++) {
+					printf("%02x", ((int)l2capSockBuf[i]) & 0xff);
+				}
+				printf("\n");
+			}
+		}
     }
   }
 
 done:
   close(l2capSock);
   close(hciSocket);
-  printf("disconnect\n");
-
   return 0;
 }


### PR DESCRIPTION
Bluetooth connection can easily be dropped. In order to support automatic reconnection :
* on linux native part : allow l2cap reconnection - default number of attempts = 5
* on script part : add 'reconnect' 'connectionDrop' events to define a reconnection policy, for an example refer to https://github.com/Lahorde/node-sensortag

TODO other platform native implementation