### PR TITLE
Added option to notify discoveries immediately

### DIFF
--- a/lib/linux/bindings.js
+++ b/lib/linux/bindings.js
@@ -29,10 +29,10 @@ nobleBindings.onStateChange = function(state) {
   this.emit('stateChange', state);
 };
 
-nobleBindings.startScanning = function(serviceUuids, allowDuplicates) {
+nobleBindings.startScanning = function(serviceUuids, allowDuplicates, immediateDiscovery) {
   this._scanServiceUuids = serviceUuids || [];
 
-  this._hciBle.startScanning(allowDuplicates);
+  this._hciBle.startScanning(allowDuplicates, immediateDiscovery);
 };
 
 nobleBindings.onScanStart = function() {

--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -20,6 +20,8 @@ var HciBle = function() {
   this._buffer = "";
 
   this._discoveries = {};
+
+  this._immediateDiscovery = false;
 };
 
 util.inherits(HciBle, events.EventEmitter);
@@ -67,7 +69,7 @@ HciBle.prototype.onStdoutData = function(data) {
       debug('rssi = ' + rssi);
 
       var previouslyDiscovered = !!this._discoveries[address];
-      var advertisement =  previouslyDiscovered ? this._discoveries[address].advertisement : {
+      var advertisement = (previouslyDiscovered && !this._immediateDiscovery) ? this._discoveries[address].advertisement : {
         localName: undefined,
         txPowerLevel: undefined,
         manufacturerData: undefined,
@@ -162,7 +164,7 @@ HciBle.prototype.onStdoutData = function(data) {
       };
 
       // only report after an even number of events, so more advertisement data can be collected
-      if (this._discoveries[address].count % 2 === 0) {
+      if (this._immediateDiscovery || this._discoveries[address].count % 2 === 0) {
         this.emit('discover', address, addressType, advertisement, rssi);
       }
     }
@@ -173,8 +175,9 @@ HciBle.prototype.onStderrData = function(data) {
   console.error('stderr: ' + data);
 };
 
-HciBle.prototype.startScanning = function(allowDuplicates) {
+HciBle.prototype.startScanning = function(allowDuplicates, immediateDiscovery) {
   this._hciBle.kill(allowDuplicates ? 'SIGUSR2' : 'SIGUSR1');
+  this._immediateDiscovery = immediateDiscovery;
 
   this.emit('scanStart');
 };

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -33,6 +33,7 @@ function Noble() {
   this._services = {};
   this._characteristics = {};
   this._descriptors = {};
+  this._immediateDiscovery = false;
 
   this._bindings.on('stateChange', this.onStateChange.bind(this));
   this._bindings.on('scanStart', this.onScanStart.bind(this));
@@ -66,6 +67,10 @@ Noble.prototype.onStateChange = function(state) {
   this.emit('stateChange', state);
 };
 
+Noble.prototype.immediateDiscovery = function(immediateDiscovery) {
+  this._immediateDiscovery = immediateDiscovery;
+};
+
 Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback) {
   if (callback) {
     this.once('scanStart', callback);
@@ -74,7 +79,7 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
   this._discoveredPeripheralUUids = [];
   this._allowDuplicates = allowDuplicates;
   
-  this._bindings.startScanning(serviceUuids, allowDuplicates);
+  this._bindings.startScanning(serviceUuids, allowDuplicates, this._immediateDiscovery);
 };
 
 Noble.prototype.onScanStart = function() {


### PR DESCRIPTION
This option disables the buffering of broadcast data. Setting this
option will let noble emit a 'discover' event for each broadcast on
linux, instead of only emitting the event for every second broadcast
received.

The BLE sensors we use are only sending a broadcast every other minute, so we don't really want to miss every other reading.

I'm not to fond of the implementation, but this was the only way I could think of that wouldn't break backwards-compability.

I'm more than happy to refactor/rewrite it.