### PR TITLE
fix firing callback more than once when read/writing descriptors

### DIFF
--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -34,7 +34,7 @@ Descriptor.prototype.toString = function() {
 
 Descriptor.prototype.readValue = function(callback) {
   if (callback) {
-    this.on('valueRead', function(data) {
+    this.once('valueRead', function(data) {
       callback(null, data);
     });
   }
@@ -52,7 +52,7 @@ Descriptor.prototype.writeValue = function(data, callback) {
   }
 
   if (callback) {
-    this.on('valueWrite', function() {
+    this.once('valueWrite', function() {
       callback(null);
     });
   }

--- a/test/test-descriptor.js
+++ b/test/test-descriptor.js
@@ -60,6 +60,18 @@ describe('Descriptor', function() {
       calledback.should.equal(true);
     });
 
+    it('should not call callback twice', function() {
+      var calledback = 0;
+
+      descriptor.readValue(function() {
+        calledback += 1;
+      });
+      descriptor.emit('valueRead');
+      descriptor.emit('valueRead');
+
+      calledback.should.equal(1);
+    });
+
     it('should callback with error, data', function() {
       var mockData = new Buffer(0);
       var callbackData = null;
@@ -104,5 +116,18 @@ describe('Descriptor', function() {
 
       calledback.should.equal(true);
     });
+
+    it('should not call callback twice', function() {
+      var calledback = 0;
+
+      descriptor.writeValue(mockData, function() {
+        calledback += 1;
+      });
+      descriptor.emit('valueWrite');
+      descriptor.emit('valueWrite');
+
+      calledback.should.equal(1);
+    });
+
   });
 });


### PR DESCRIPTION
Hi,

The callback registered to listen to valueRead and valueWrite of descriptors are kept indefinitely which I believe is a typo. I've added tests and a fix. Please let me know if I'm missing something or if this behavior is intentional. Thanks.

And thanks for the brilliant module =)