### PR TITLE
Fixed out of order packets sent on Linux

### DIFF
--- a/lib/linux/l2cap-ble.js
+++ b/lib/linux/l2cap-ble.js
@@ -155,7 +155,7 @@ L2capBle.prototype.onStdoutData = function(data) {
         this._currentCommand = null;
 
         while(this._commandQueue.length) {
-          this._currentCommand = this._commandQueue.pop();
+          this._currentCommand = this._commandQueue.shift();
 
           debug(this._address + ': write: ' + this._currentCommand.buffer.toString('hex'));
           this._l2capBle.stdin.write(this._currentCommand.buffer.toString('hex') + '\n');


### PR DESCRIPTION
A pop() command was causing messages to be sent out of order. This needed to be a shift(), taking the first element of the array rather than the last.