### PR TITLE
Fix error handling and adapter binding

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -40,7 +40,6 @@ HciBle.prototype.onStdoutData = function(data) {
 
     this._buffer = this._buffer.substring(newLineIndex + 1);
 
-
     debug('line = ' + line);
 
     if ((found = line.match(/^adapterState (.*)$/))) {
@@ -60,7 +59,7 @@ HciBle.prototype.onStdoutData = function(data) {
         console.log('               [sudo] NOBLE_HCI_DEVICE_ID=x node ...');
       }
 
-        this.emit('stateChange', adapterState);
+      this.emit('stateChange', adapterState);
     } else if ((found = line.match(/^event (.*)$/))) {
       var event = found[1];
       var splitEvent = event.split(',');

--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -40,6 +40,7 @@ HciBle.prototype.onStdoutData = function(data) {
 
     this._buffer = this._buffer.substring(newLineIndex + 1);
 
+
     debug('line = ' + line);
 
     if ((found = line.match(/^adapterState (.*)$/))) {
@@ -53,7 +54,13 @@ HciBle.prototype.onStdoutData = function(data) {
         console.log('               https://github.com/sandeepmistry/noble#running-on-linux');
       }
 
-      this.emit('stateChange', adapterState);
+      if (adapterState === 'unsupported') {
+        console.log('noble warning: adapter does not support Bluetooth Low Energy (BLE, Bluetooth Smart).');
+        console.log('               Try to run with environment variable:');
+        console.log('               [sudo] NOBLE_HCI_DEVICE_ID=x node ...');
+      }
+
+        this.emit('stateChange', adapterState);
     } else if ((found = line.match(/^event (.*)$/))) {
       var event = found[1];
       var splitEvent = event.split(',');

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -134,7 +134,7 @@ Noble.prototype.onConnect = function(peripheralUuid, error) {
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
-    peripheral.state = 'connected';
+    peripheral.state = error ? 'error' : 'connected';
     peripheral.emit('connect', error);
   } else {
     console.warn('noble: unknown peripheral ' + peripheralUuid + ' connected!');

--- a/src/l2cap-ble.c
+++ b/src/l2cap-ble.c
@@ -101,14 +101,14 @@ int main(int argc, const char* argv[]) {
   // open controller
   hciSocket = hci_open_dev(hciDeviceId);
   if (hciSocket == -1) {
-    printf("connect hci_open_dev(hci%i):%s\n", hciDeviceId, strerror(errno));
+    printf("connect hci_open_dev(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
 
   // get local controller address
   result = hci_devinfo(hciDeviceId, &device_info);
    if (result == -1) {
-    printf("connect hci_deviceinfo (hci%i):%s\n", hciDeviceId, strerror(errno));
+    printf("connect hci_deviceinfo(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
   ba2str(&device_info.bdaddr, controller_address);
@@ -117,7 +117,7 @@ int main(int argc, const char* argv[]) {
   // create socket
   l2capSock = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
   if (l2capSock  == -1) {
-    printf("connect socket(hci%i):%s\n", hciDeviceId, strerror(errno));
+    printf("connect socket(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
 
@@ -130,7 +130,7 @@ int main(int argc, const char* argv[]) {
   sockAddr.l2_cid = htobs(ATT_CID);
   result = bind(l2capSock, (struct sockaddr*)&sockAddr, sizeof(sockAddr));
   if (result == -1) {
-    printf("connect bind(hci%i):%s\n", hciDeviceId, strerror(errno));
+    printf("connect bind(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
 
@@ -145,7 +145,7 @@ int main(int argc, const char* argv[]) {
   if (result == -1) {
     char buf[1024] = { 0 };
     ba2str( &sockAddr.l2_bdaddr, buf );
-    printf("connect (hci%i): %s\n", hciDeviceId, strerror(errno));
+    printf("connect connect(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
 
@@ -153,7 +153,7 @@ int main(int argc, const char* argv[]) {
   l2capConnInfoLen = sizeof(l2capConnInfo);
   result = getsockopt(l2capSock, SOL_L2CAP, L2CAP_CONNINFO, &l2capConnInfo, &l2capConnInfoLen);
   if (result == -1) {
-    printf("connect getsockopt (hci%i): :%s\n", hciDeviceId, strerror(errno));
+    printf("connect getsockopt(hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
   hciHandle = l2capConnInfo.hci_handle;

--- a/src/l2cap-ble.c
+++ b/src/l2cap-ble.c
@@ -8,6 +8,22 @@
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
 
+/*/
+for trouble shooting:
+
+    enable kernel dynamic debug logging via dmsg for ble:
+echo "file net/bluetooth/hci_conn.c =flmtp" > /sys/kernel/debug/dynamic_debug/control
+    and repeat with hci_core.c, lcap_sock.c, lcap.core.c or others
+
+    disable with
+echo "file net/bluetooth/hci_conn.c =_" > /sys/kernel/debug/dynamic_debug/control
+
+    check with
+grep "\[bluetooth\][a-z_]* =[^_ ]\+" /sys/kernel/debug/dynamic_debug/control
+
+wildcards did not work for me, ymmv.
+/*/
+
 #define ATT_CID 4
 
 #define BDADDR_LE_PUBLIC       0x01
@@ -36,9 +52,11 @@ static void signalHandler(int signal) {
 int main(int argc, const char* argv[]) {
   char *hciDeviceIdOverride = NULL;
   int hciDeviceId = 0;
-  int hciSocket;
+  char controller_address[18];
+  struct hci_dev_info device_info;
+  int hciSocket = -1;
 
-  int l2capSock;
+  int l2capSock = -1;
   struct sockaddr_l2 sockAddr;
   struct l2cap_conninfo l2capConnInfo;
   socklen_t l2capConnInfoLen;
@@ -80,20 +98,41 @@ int main(int argc, const char* argv[]) {
     hciDeviceId = 0; // use device 0, if device id is invalid
   }
 
+  // open controller
   hciSocket = hci_open_dev(hciDeviceId);
+  if (hciSocket == -1) {
+    printf("connect hci_open_dev(hci%i):%s\n", hciDeviceId, strerror(errno));
+    goto done;
+  }
+
+  // get local controller address
+  result = hci_devinfo(hciDeviceId, &device_info);
+   if (result == -1) {
+    printf("connect hci_deviceinfo (hci%i):%s\n", hciDeviceId, strerror(errno));
+    goto done;
+  }
+  ba2str(&device_info.bdaddr, controller_address);
+  printf("info using %s@hci%i\n", controller_address, hciDeviceId);
 
   // create socket
   l2capSock = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+  if (l2capSock  == -1) {
+    printf("connect socket(hci%i):%s\n", hciDeviceId, strerror(errno));
+    goto done;
+  }
 
   // bind
   memset(&sockAddr, 0, sizeof(sockAddr));
   sockAddr.l2_family = AF_BLUETOOTH;
-  bacpy(&sockAddr.l2_bdaddr, BDADDR_ANY);
+   // Bind socket to the choosen adapter by using the controllers BT-address as source
+   // see l2cap_chan_connect source and hci_get_route in linux/net/bluetooth
+  bacpy(&sockAddr.l2_bdaddr, &device_info.bdaddr);
   sockAddr.l2_cid = htobs(ATT_CID);
-
   result = bind(l2capSock, (struct sockaddr*)&sockAddr, sizeof(sockAddr));
-
-  printf("bind %s\n", (result == -1) ? strerror(errno) : "success");
+  if (result == -1) {
+    printf("connect bind(hci%i):%s\n", hciDeviceId, strerror(errno));
+    goto done;
+  }
 
   // connect
   memset(&sockAddr, 0, sizeof(sockAddr));
@@ -103,16 +142,23 @@ int main(int argc, const char* argv[]) {
   sockAddr.l2_cid = htobs(ATT_CID);
 
   result = connect(l2capSock, (struct sockaddr *)&sockAddr, sizeof(sockAddr));
-
-  l2capConnInfoLen = sizeof(l2capConnInfo);
-  getsockopt(l2capSock, SOL_L2CAP, L2CAP_CONNINFO, &l2capConnInfo, &l2capConnInfoLen);
-  hciHandle = l2capConnInfo.hci_handle;
-
-  printf("connect %s\n", (result == -1) ? strerror(errno) : "success");
-
   if (result == -1) {
+    char buf[1024] = { 0 };
+    ba2str( &sockAddr.l2_bdaddr, buf );
+    printf("connect (hci%i): %s\n", hciDeviceId, strerror(errno));
     goto done;
   }
+
+  // get hci_handle
+  l2capConnInfoLen = sizeof(l2capConnInfo);
+  result = getsockopt(l2capSock, SOL_L2CAP, L2CAP_CONNINFO, &l2capConnInfo, &l2capConnInfoLen);
+  if (result == -1) {
+    printf("connect getsockopt (hci%i): :%s\n", hciDeviceId, strerror(errno));
+    goto done;
+  }
+  hciHandle = l2capConnInfo.hci_handle;
+
+  printf("connect success\n");
 
   while(1) {
     FD_ZERO(&rfds);
@@ -197,8 +243,10 @@ int main(int argc, const char* argv[]) {
   }
 
 done:
-  close(l2capSock);
-  close(hciSocket);
+  if (l2capSock != -1)
+    close(l2capSock);
+  if (hciSocket != -1)
+    close(hciSocket);
   printf("disconnect\n");
 
   return 0;


### PR DESCRIPTION
After some promising tests I suddenly had some ugly Problems with SensorTag after a reboot. It just stopped working. `node test.js` resulted in a blinking cursor on the next line. 

A fresh checkout stopped with the new message about missing privilege.  
After setting the capabilities I got the blinking cursor again. Now I ran `DEBUG=* node test.js` with the following result: 

    noble stateChange unsupported +0ms

That is strange. Before booting my BLE capable device was `hci1` and the default device was `hci0`. Now it is the other way round: default is `hci1` and `hci0` supports BLE. This was consistent across multiple boots. Probably something about Plug&Play. 

After using `NOBLE_HCI_DEVICE_ID=0  DEBUG=* node test.js` I got:

    l2cap-ble BC:xx:xx:xx:xx:xx: line = connect Transport endpoint is not connected +0ms

I traced it to `src/l2cap-ble.c`. The error handling there ignored some intermediate errors so I corrected it. The root error was 

    l2cap-ble BC:xx:xx:xx:xx:xx: line = connect (hci0): Invalid request code

After browsing kernel sources in the `net/bluetooth` tree I decided to take a look at the debug output there. I enabled dynamic kernel debug via dmesg for ble:

    echo "file net/bluetooth/hci_conn.c =flmtp" > /sys/kernel/debug/dynamic_debug/control
   and repeat with `hci_core.c`, `lcap_sock.c`, `lcap.core.c`

there it hit me: `l2cap_chan_connect` was using `hci1`.
 
    ...
    bluetooth:hci_get_route:482: 00:00:00:00:00:00 -> bc:xx:xx:xx:xx:xx
    bluetooth:hci_connect:711: hci1 dst bc:xx:xx:xx:xx:xx type 0x80
    ...

It chooses which source adapter to use by calling `hci_get_route` which is using the default adapter if no source BT-address is set which is what l2cap-ble was doing. 

Please pull my change sets. 
