### PR TITLE
Detect type of event of the advertising info

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -29,6 +29,33 @@ HciBle.prototype.onClose = function(code) {
 };
 
 HciBle.prototype.onStdoutData = function(data) {
+  function evtTypeToString(evt_type)
+  {
+    evt_type = parseInt(evt_type);
+    var evt_str;
+    switch (evt_type) {
+    case 0x00:
+      evt_str = 'ADV_IND';
+      break;
+    case 0x01:
+      evt_str = 'ADV_DIRECT_IND';
+      break;
+    case 0x02:
+      evt_str = 'ADV_SCAN_IND';
+      break;
+    case 0x03:
+      evt_str = 'ADV_NONCONN_IND';
+      break;
+    case 0x04:
+      evt_str = 'SCAN_RSP';
+      break;
+    default:
+      evt_str = 'Unknown';
+    }
+
+    return evt_str;
+  }
+
   this._buffer += data.toString();
 
   debug('buffer = ' + JSON.stringify(this._buffer));
@@ -64,11 +91,13 @@ HciBle.prototype.onStdoutData = function(data) {
       var event = found[1];
       var splitEvent = event.split(',');
 
-      var address = splitEvent[0];
-      var addressType = splitEvent[1];
-      var eir = new Buffer(splitEvent[2], 'hex');
-      var rssi = parseInt(splitEvent[3], 10);
+      var evt_type = splitEvent[0];
+      var address = splitEvent[1];
+      var addressType = splitEvent[2];
+      var eir = new Buffer(splitEvent[3], 'hex');
+      var rssi = parseInt(splitEvent[4], 10);
 
+      debug('evt_type = ' + evtTypeToString(evt_type) + '(' + evt_type + ')');
       debug('address = ' + address);
       debug('addressType = ' + addressType);
       debug('eir = ' + eir.toString('hex'));

--- a/src/hci-ble.c
+++ b/src/hci-ble.c
@@ -166,7 +166,10 @@ int main(int argc, const char* argv[])
       leAdvertisingInfo = (le_advertising_info *)(leMetaEvent->data + 1);
       ba2str(&leAdvertisingInfo->bdaddr, btAddress);
 
-      printf("event %s,%s,", btAddress, (leAdvertisingInfo->bdaddr_type == LE_PUBLIC_ADDRESS) ? "public" : "random");
+      printf("event %u,%s,%s,",
+        (unsigned int)leAdvertisingInfo->evt_type,
+        btAddress,
+        (leAdvertisingInfo->bdaddr_type == LE_PUBLIC_ADDRESS) ? "public" : "random");
 
       for (i = 0; i < leAdvertisingInfo->length; i++) {
           printf("%02x", leAdvertisingInfo->data[i]);


### PR DESCRIPTION
This addresses adding the capability to detect the type of the advertising info discussed in the issue: "Added option to notify discoveries immediately #108"