### PR TITLE
persistent peripherals between calls to .startScanning() on mavericks

### DIFF
--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -138,12 +138,12 @@ nobleBindings.on('kCBMsgId37', function(args) {
   var uuid = new Buffer(deviceUuid, 'hex');
   uuid.isUuid = true;
 
-  this._peripherals[deviceUuid] = {
-    uuid: uuid,
-    address: undefined,
-    advertisement: advertisement,
-    rssi: rssi
-  };
+  if(!this._peripherals[deviceUuid]) {
+    this._peripherals[deviceUuid] = {};
+  }
+  this._peripherals[deviceUuid].uuid = uuid;
+  this._peripherals[deviceUuid].advertisement = advertisement;
+  this._peripherals[deviceUuid].rssi = rssi;
 
   (function(deviceUuid, advertisement, rssi) {
     uuidToAddress(deviceUuid, function(error, address) {


### PR DESCRIPTION
periphal objects stored in `_peripherals` are no longer overwritten when repeated picked up while scanning