### PR TITLE
On Linux, refresh serviceUuids for incoming advertisement

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -88,6 +88,7 @@ HciBle.prototype.onStdoutData = function(data) {
       if (discoveryCount % 2 === 0) {
         // reset service data every second event
         advertisement.serviceData = [];
+        advertisement.serviceUuids = [];
       }
 
       var i = 0;


### PR DESCRIPTION
If an advertising device changes its service UUIDs, the old and redundant ones remain cached - even if they are no longer being advertised. As far as I'm aware this isn't desired behaviour, but it was causing problems in a use case I was exploring. When the service data is cleaned up, the service UUIDs should be as well.  

In reality, only doing this every second event (as the implementation currently does), might not be wholly efficient as it could miss an instantaneous new service UUID - but will pick it up soon after anyway.