### PR TITLE
fix this._discoveredPeripheralUUids = []; variable not initalized in constructor

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -33,6 +33,7 @@ function Noble() {
   this._services = {};
   this._characteristics = {};
   this._descriptors = {};
+  this._discoveredPeripheralUUids = [];
 
   this._bindings.on('stateChange', this.onStateChange.bind(this));
   this._bindings.on('scanStart', this.onScanStart.bind(this));


### PR DESCRIPTION
Clearly not giving you trouble currently, but when I copied this code and ran it in react native it came up, so why not fix it.