### PR TITLE
Fix a potential exception when accessing a non existent element

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -143,7 +143,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04) ? this._discoveries[address].connectable : (type !== 0x03);
+  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
 
   this._discoveries[address] = {
     address: address,


### PR DESCRIPTION
It could happen (and it sometime does on my machine) that an the
_discoveries map does not contain the address when the type is 0x04