### PR TITLE
Recover from windows failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 1.2.1
+
+ * Use latest v0.4.1 bluetooth-hci-socket dependency (for kernel 4.1.x disconnect workaround)
+ * Add read + write LE host supported commands (for kernel 4.1.x disconnect workaround)
+ * Fix a potential exception when accessing a non existent element ([@Loghorn](https://github.com/Loghorn))
+
 ## Version 1.2.0
 
  * Use v0.4.0 of bluetooth-hci-socket

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ See [Configure Intel Edison for Bluetooth LE (Smart) Development](http://rexstjo
    * Compatible Bluetooth 4.0 USB adapter
    * [WinUSB](https://msdn.microsoft.com/en-ca/library/windows/hardware/ff540196(v=vs.85).aspx) driver setup for Bluetooth 4.0 USB adapter, using [Zadig tool](http://zadig.akeo.ie/)
 
+## Notes
+
+### Maximum simulanteous connections
+
+| Platform |     |
+| :------- | --- |
+| OS X 10.11 (El Capitan) | 6 |
+| Linux/Windows - Adapter dependent | |
+| | 5 (CSR based adapter) |
+
 ## Install
 
 ```sh

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -73,7 +73,6 @@ NobleBindings.prototype.init = function() {
 
   this._hci.on('stateChange', this.onStateChange.bind(this));
   this._hci.on('usbDeviceUnavailable', this.onUsbDeviceUnavailable.bind(this));
-  this._hci.on('usbDeviceDetached', this.onUsbDeviceDetached.bind(this));
   this._hci.on('leConnComplete', this.onLeConnComplete.bind(this));
   this._hci.on('leConnUpdateComplete', this.onLeConnUpdateComplete.bind(this));
   this._hci.on('rssiRead', this.onRssiRead.bind(this));
@@ -132,13 +131,6 @@ NobleBindings.prototype.onScanStop = function() {
 
 NobleBindings.prototype.onUsbDeviceUnavailable = function() {
   this.emit('usbDeviceUnavailable');
-};
-
-NobleBindings.prototype.onUsbDeviceDetached = function() {
-  this._handles = {};
-  this._gatts = {};
-  this._aclStreams = {};
-  this.emit('usbDeviceDetached');
 };
 
 NobleBindings.prototype.onDiscover = function(status, address, addressType, connectable, advertisement, rssi) {

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -67,7 +67,6 @@ var HCI_OE_USER_ENDED_CONNECTION = 0x13;
 var STATUS_MAPPER = require('./hci-status');
 
 var Hci = function() {
-  this.isPoweredOn = false;
   this._socket = new BluetoothHciSocket();
 
   this._socket.on('usbDeviceDetached', this.onUsbDeviceDetached.bind(this));
@@ -96,24 +95,14 @@ Hci.prototype.init = function() {
   }
 
   this.pollIsDevUp();
-  setTimeout(this.pollIsPoweredOn.bind(this), 1000);
 };
 
 Hci.prototype.onUsbDeviceDetached = function() {
-  this.isPoweredOn = false;
   this.emit('usbDeviceDetached');
 };
 
 Hci.prototype.onUsbDeviceAttached = function() {
   this.reset();
-};
-
-Hci.prototype.pollIsPoweredOn = function() {
-  if (!this.isPoweredOn) {
-    this.reset();
-    
-    setTimeout(this.pollIsPoweredOn.bind(this), 1500);
-  }
 };
 
 Hci.prototype.pollIsDevUp = function() {
@@ -129,7 +118,6 @@ Hci.prototype.pollIsDevUp = function() {
       this.readLeHostSupported();
       this.readBdAddr();
     } else {
-      this.isPoweredOn = false;
       this.emit('stateChange', 'poweredOff');
     }
 
@@ -503,7 +491,6 @@ Hci.prototype.onSocketError = function(error) {
   debug('onSocketError: ' + error.message);
 
   if (error.message === 'Operation not permitted') {
-    this.isPoweredOn = false;
     this.emit('stateChange', 'unauthorized');
   } else if (error.message === 'Network is down') {
     // no-op
@@ -525,7 +512,6 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
     var lmpSubVer = result.readUInt16LE(6);
 
     if (hciVer < 0x06) {
-      this.isPoweredOn = false;
       this.emit('stateChange', 'unsupported');
     } else {
       this.setScanEnabled(false, true);
@@ -541,7 +527,6 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
 
     this.emit('addressChange', this.address);
   } else if (cmd === LE_SET_SCAN_PARAMETERS_CMD) {
-    this.isPoweredOn = true;
     this.emit('stateChange', 'poweredOn');
 
     this.emit('leScanParametersSet');

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -143,7 +143,7 @@ Hci.prototype.reset = function(data) {
   this._socket._isUp = !this._socket._isUp;
   
   try {
-    this._socket.bindRaw(deviceId);
+    this._socket.bindRaw();
     this._socket.start();
   } catch (error) {
     this.emit('usbDeviceUnavailable');

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -142,8 +142,14 @@ Hci.prototype.pollIsDevUp = function() {
 
 Hci.prototype.reset = function(data) {
   this._socket._isUp = !this._socket._isUp;
-  this._socket.bindRaw();
-  this._socket.start();
+  
+  try {
+    this._socket.bindRaw(deviceId);
+    this._socket.start();
+  } catch (error) {
+    this.emit('usbDeviceUnavailable');
+  }
+
   this.readBdAddr();
 }
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -110,7 +110,6 @@ Hci.prototype.onUsbDeviceAttached = function() {
 
 Hci.prototype.pollIsPoweredOn = function() {
   if (!this.isPoweredOn) {
-    //this._socket.stop();
     this.reset();
     
     setTimeout(this.pollIsPoweredOn.bind(this), 1500);

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -67,10 +67,8 @@ var HCI_OE_USER_ENDED_CONNECTION = 0x13;
 var STATUS_MAPPER = require('./hci-status');
 
 var Hci = function() {
+  this.isPoweredOn = false;
   this._socket = new BluetoothHciSocket();
-
-  this._socket.on('usbDeviceDetached', this.onUsbDeviceDetached.bind(this));
-  this._socket.on('usbDeviceAttached', this.onUsbDeviceAttached.bind(this));
 
   this._isDevUp = null;
 
@@ -95,14 +93,14 @@ Hci.prototype.init = function() {
   }
 
   this.pollIsDevUp();
+  setTimeout(this.pollIsPoweredOn.bind(this), 1000);
 };
 
-Hci.prototype.onUsbDeviceDetached = function() {
-  this.emit('usbDeviceDetached');
-};
-
-Hci.prototype.onUsbDeviceAttached = function() {
-  this.reset();
+Hci.prototype.pollIsPoweredOn = function() {
+  if (!this.isPoweredOn) {
+    this.reset();
+    setTimeout(this.pollIsPoweredOn.bind(this), 1500);
+  }
 };
 
 Hci.prototype.pollIsDevUp = function() {
@@ -118,6 +116,7 @@ Hci.prototype.pollIsDevUp = function() {
       this.readLeHostSupported();
       this.readBdAddr();
     } else {
+      this.isPoweredOn = false;
       this.emit('stateChange', 'poweredOff');
     }
 
@@ -491,6 +490,7 @@ Hci.prototype.onSocketError = function(error) {
   debug('onSocketError: ' + error.message);
 
   if (error.message === 'Operation not permitted') {
+    this.isPoweredOn = false;
     this.emit('stateChange', 'unauthorized');
   } else if (error.message === 'Network is down') {
     // no-op
@@ -512,6 +512,7 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
     var lmpSubVer = result.readUInt16LE(6);
 
     if (hciVer < 0x06) {
+      this.isPoweredOn = false;
       this.emit('stateChange', 'unsupported');
     } else {
       this.setScanEnabled(false, true);
@@ -527,6 +528,7 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
 
     this.emit('addressChange', this.address);
   } else if (cmd === LE_SET_SCAN_PARAMETERS_CMD) {
+    this.isPoweredOn = true;
     this.emit('stateChange', 'poweredOn');
 
     this.emit('leScanParametersSet');

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -82,7 +82,7 @@ Noble.prototype.onUsbDeviceUnavailable = function() {
 };
 
 Noble.prototype.onUsbDeviceDetached = function() {
-  for (uuid in this._peripherals) {
+  for (var uuid in this._peripherals) {
     var peripheral = this._peripherals[uuid];
 
     peripheral.state = 'disconnected';

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -41,7 +41,6 @@ function Noble() {
   this._bindings.on('discover', this.onDiscover.bind(this));
   this._bindings.on('connect', this.onConnect.bind(this));
   this._bindings.on('usbDeviceUnavailable', this.onUsbDeviceUnavailable.bind(this));
-  this._bindings.on('usbDeviceDetached', this.onUsbDeviceDetached.bind(this));
   this._bindings.on('disconnect', this.onDisconnect.bind(this));
   this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
   this._bindings.on('servicesDiscover', this.onServicesDiscover.bind(this));
@@ -78,17 +77,6 @@ Noble.prototype.onStateChange = function(state) {
 };
 
 Noble.prototype.onUsbDeviceUnavailable = function() {
-  this.emit('usbDeviceUnavailable');
-};
-
-Noble.prototype.onUsbDeviceDetached = function() {
-  for (var uuid in this._peripherals) {
-    var peripheral = this._peripherals[uuid];
-
-    peripheral.state = 'disconnected';
-    peripheral.emit('disconnect');
-  }
-  
   this.emit('usbDeviceUnavailable');
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "name": "noble",
   "description": "A Node.js BLE (Bluetooth Low Energy) central library.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/sandeepmistry/noble.git"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "~2.2.0"
   },
   "optionalDependencies": {
-    "bluetooth-hci-socket": "~0.4.0",
+    "bluetooth-hci-socket": "~0.4.1",
     "bplist-parser": "0.0.6",
     "xpc-connection": "~0.1.4"
   },


### PR DESCRIPTION
This attempts to make noble on Windows more stable:
- Sometimes when noble starts bluetooth dongle is not detected, in this case attempt to reset dongle
- Emit event if dongle not inserted or invalid dongle inserted