### PR TITLE
Handle service discovery requests from peripheral (rather than letting them timeout)

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -259,6 +259,16 @@ NobleBindings.prototype.onAclDataPkt = function(handle, cid, data) {
   }
 };
 
+NobleBindings.prototype.enableReadByGroupResponse = function(peripheralUuid, enable) {
+  var handle = this._handles[peripheralUuid];
+  var gatt = this._gatts[handle];
+
+  if (gatt) {
+    gatt.enableReadByGroupResponse(enable);
+  } else {
+    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+  }
+};
 
 NobleBindings.prototype.discoverServices = function(peripheralUuid, uuids) {
   var handle = this._handles[peripheralUuid];

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -65,6 +65,8 @@ var Gatt = function(address, aclStream) {
   this._mtu = 23;
   this._security = 'low';
 
+  this._readByGroupResponseEnabled = true;
+
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
   this.onAclStreamEncryptBinded = this.onAclStreamEncrypt.bind(this);
   this.onAclStreamEncryptFailBinded = this.onAclStreamEncryptFail.bind(this);
@@ -86,7 +88,13 @@ Gatt.prototype.onAclStreamData = function(cid, data) {
   if (this._currentCommand && data.toString('hex') === this._currentCommand.buffer.toString('hex')) {
     debug(this._address + ': echo ... echo ... echo ...');
   } else if (data[0] % 2 === 0) {
-    debug(this._address + ': ignoring request/command ...');
+    var requestType = data[0];
+
+    if (requestType === ATT_OP_READ_BY_GROUP_REQ) {
+      this.handleReadByGroupRequest(data);
+    } else {
+      debug(this._address + ': ignoring request/command 0x' + requestType.toString(16));
+    }
   } else if (data[0] === ATT_OP_HANDLE_NOTIFY || data[0] === ATT_OP_HANDLE_IND) {
     var valueHandle = data.readUInt16LE(1);
     var valueData = data.slice(3);
@@ -161,6 +169,31 @@ Gatt.prototype.writeAtt = function(data) {
 
   this._aclStream.write(ATT_CID, data);
 };
+
+Gatt.prototype.errorResponse = function(opcode, handle, status) {
+  var buf = new Buffer(5);
+
+  buf.writeUInt8(ATT_OP_ERROR, 0);  
+  buf.writeUInt8(opcode, 1);
+  buf.writeUInt16LE(handle, 2);
+  buf.writeUInt8(status, 4);        
+
+  return buf;
+};
+
+Gatt.prototype.handleReadByGroupRequest = function(request) {
+  if (!this._readByGroupResponseEnabled) {
+    return;
+  }
+
+  var startHandle = request.readUInt16LE(1);
+  var endHandle = request.readUInt16LE(3);
+  var uuid = request.slice(5).toString('hex').match(/.{1,2}/g).reverse().join('');
+
+  debug('read by group: startHandle = 0x' + startHandle.toString(16) + ', endHandle = 0x' + endHandle.toString(16) + ', uuid = 0x' + uuid.toString(16));
+
+  this.writeAtt(this.errorResponse(ATT_OP_READ_BY_GROUP_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND));
+}
 
 Gatt.prototype._queueCommand = function(buffer, callback, writeCallback) {
   this._commandQueue.push({
@@ -283,6 +316,10 @@ Gatt.prototype.exchangeMtu = function(mtu) {
       this.emit('mtu', this._address, 23);
     }
   }.bind(this));
+};
+
+Gatt.prototype.enableReadByGroupResponse = function(enable) {
+  this._readByGroupResponseEnabled = enable;
 };
 
 Gatt.prototype.discoverServices = function(uuids) {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -175,6 +175,10 @@ Noble.prototype.onDisconnect = function(peripheralUuid) {
   }
 };
 
+Noble.prototype.enableReadByGroupResponse = function(peripheralUuid, enable) {
+  this._bindings.enableReadByGroupResponse(peripheralUuid, enable);
+};
+
 Noble.prototype.updateRssi = function(peripheralUuid) {
   this._bindings.updateRssi(peripheralUuid);
 };

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,6 +57,22 @@ Peripheral.prototype.disconnect = function(callback) {
   this._noble.disconnect(this.id);
 };
 
+Peripheral.prototype.enableReadByGroupResponse = function(enable) {
+  var self = this;
+  var setter = function () {
+    self._noble.enableReadByGroupResponse(self.id, enable);
+  }
+  if (this.state === 'connected') {
+    setter();
+  } else {
+    this.once('connect', function(error) {
+      if (!error) {
+        setter();
+      }
+    });
+  }
+}
+
 Peripheral.prototype.updateRssi = function(callback) {
   if (callback) {
     this.once('rssiUpdate', function(rssi) {


### PR DESCRIPTION
Problem summary
---------------

We're using Noble and, on connecting to a remote peripheral, the remote peripheral attempts to discover services on the Noble end of things, Noble ignores the discovery request and after 30 seconds the peripheral times out on waiting for a response and shuts down any further interaction with Noble.

Steps
-----

The peripheral calls:
```c++
sd_ble_gattc_primary_services_discover(this->_connectionHandle, 1, NULL);
```

If we enable debug output for `noble/lib/hci-socket/hci.js` this results in:
```
hci write acl data pkt - writing: 024600070003000400020001 +2ms
hci onSocketData: 0246200b0007000400100100ffff0028 +12ms
hci   event type = 2 +0ms
hci       cid = 4 +0ms
hci       handle = 70 +0ms
hci       data = 100100ffff0028 +0ms
```

This data ends up being handled in [`noble/lib/hci-socket/gatt.js`](https://github.com/sandeepmistry/noble/blob/31ce8241851999072cf6777ec73c2e4dbda72636/lib/hci-socket/gatt.js#L89) by `Gatt.prototype.onAclStreamData` which just ignores it like so:
```js
...
} else if (data[0] % 2 === 0) {
  debug(this._address + ': ignoring request/command ...');
} ...
```

Analysis
--------

The request being ignored is `0x10` (the first byte of `data`) which is `ATT_OP_READ_BY_GROUP_REQ`.

We can look at how this is handled in corresponding Bleno logic in [`bleno/lib/hci-socket/gatt.js`](https://github.com/sandeepmistry/bleno/blob/e7dbeb8c9fa4bf51523a8aa20e76c3a90725f67d/lib/hci-socket/gatt.js#L501).

If we look at the Bleno code we find we can decode the request into:
```
startHandle 1
endHandle 65535
uuid 2800
```

Solution
--------

Looking at the Bleno code we can see that the simplest thing is to respond with an error response saying there are no services to be discovered.

We can do this by copying over some of the Bleno logic into Noble - see commit [`0223525`](/george-hawkins/noble/commit/0223525).

If we then enable debug output for `att` with a test program we can see that we now respond to the `ATT_OP_READ_BY_GROUP_REQ`:
```
$ DEBUG=att node ./ble-logger.js
Scanning...
1. de:72:b8:24:91:e3 (rssi -73dBm)
Choose a device: 1
connecting to de:72:b8:24:91:e3
  att de:72:b8:24:91:e3: write: 020001 +0ms
  att read by group: startHandle = 0x1, endHandle = 0xffff, uuid = 0x2800 +14ms
  att de:72:b8:24:91:e3: write: 011001000a +0ms
  att de:72:b8:24:91:e3: new MTU is 23 +15ms
  att de:72:b8:24:91:e3: write: 100100ffff0028 +0ms
  att de:72:b8:24:91:e3: write: 100c00ffff0028 +30ms
  att de:72:b8:24:91:e3: write: 080c00ffff0328 +31ms
  att de:72:b8:24:91:e3: write: 080f00ffff0328 +30ms
  att de:72:b8:24:91:e3: write: 081100ffff0328 +29ms
  att de:72:b8:24:91:e3: write: 081300ffff0328 +30ms
  att de:72:b8:24:91:e3: write: 081600ffff0328 +30ms
  att de:72:b8:24:91:e3: write: 081400ffff0229 +31ms
  att de:72:b8:24:91:e3: write: 1216000100 +29ms
...
```

Commit `0223525` is tiny, the following commit - [`287ffff`](/george-hawkins/noble/commit/287ffff) - is much larger but is just all boilerplate allowing one to disable this behavior if required by calling:
```
peripheral.enableReadByGroupResponse(false);
```

`287ffff` is just there for completeness but there's probably no good reason to merge it in.

Discussion
----------

As I understand it technically every GATT server is required to at least implement the services "Generic Access" and "Generic Attribute" so responding to the discovery request by saying there are no services isn't technically correct behavior.

The Nordic BLE stack however doesn't object and presumably other stacks are lenient in the same fashion.

However one could use Bleno to generate reponses that include details for these two services.

Currently if you mix Bleno and Noble the Bleno logic won't respond to the `'leConnComplete'` event generated when the Noble logic connects to the peripheral.

This is due to this check in [`bleno/.../hci-socket/bindings.js`](https://github.com/sandeepmistry/bleno/blob/918e8d6b0047995cb56a69964d1cbefc2435d4e1/lib/hci-socket/bindings.js#L131):
```js
if (role !== 1) {
  // not slave, ignore
  return;
}
```

If you remove this check then simply including `require('bleno')` in your program will then do everything necessary - as part of the basic setup the `'leConnComplete'` event listener is installed by `BlenoBindings.init()`:
```
Trace:
    at BlenoBindings.init (/home/ghawkins/git/zootope-clients/ble-logger/node_modules/bleno/lib/hci-socket/bindings.js:86:9)
    at new Bleno (/home/ghawkins/git/zootope-clients/ble-logger/node_modules/bleno/lib/bleno.js:46:18)
    at Object.<anonymous> (/home/ghawkins/git/zootope-clients/ble-logger/node_modules/bleno/index.js:3:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    ...
```

If you use a version of Bleno modified to remove the `role` check, as described above, with a version of Noble that either doesn't have the `ATT_OP_READ_BY_GROUP_REQ` logic above or has disabled it (by calling `peripheral.enableReadByGroupResponse(false)`) then, without any further setup, Bleno will handle responding  to any discovery request, with the services "Generic Access" (0x1800) and "Generic Attribute" (0x1801) as setup in [`bleno/.../hci-socket/gatt.js`](https://github.com/sandeepmistry/bleno/blob/e7dbeb8c9fa4bf51523a8aa20e76c3a90725f67d/lib/hci-socket/gatt.js#L83):
```js
{
  uuid: '1800',
  characteristics: [
    ...
  ]
},
{
  uuid: '1801',
  characteristics: [
    ...
  ]
}

```

Almost perfect - however the Bleno logic will also respond to all the `'data'` messages that Noble handles. So currently e.g. something like `ATT_OP_HANDLE_NOTIFY` coming in from the peripheral will be properly handled by the Noble logic but will also end up being handled by the `default` case of the `switch` statement in the Bleno Gatt [`handleRequest`](https://github.com/sandeepmistry/bleno/blob/e7dbeb8c9fa4bf51523a8aa20e76c3a90725f67d/lib/hci-socket/gatt.js#L336) logic:
```js
default:
...
  response = this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP);
  break;
```
I.e. it will respond with an error to pretty much anything that Noble is actually happy to handle.

The current logic in the [`nRF8001::poll()`](https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/d56811b1af88ee000e8fd0fe7ecfbeb064d8b877/nRF8001.cpp#L810) method of [arduino-BLEPeripheral](https://github.com/sandeepmistry/arduino-BLEPeripheral) doesn't complain about getting an error response after e.g. initiating a notify but it's hard to imagine all BLE peripheral logic would definitely be so indifferent.

So handling things with a mix of Bleno and Noble would require a bit more work to get the two working harmoniously together.