### PR TITLE
Pass notification state to characteristic notify callback

### DIFF
--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -87,8 +87,8 @@ Characteristic.prototype.broadcast = function(broadcast, callback) {
 
 Characteristic.prototype.notify = function(notify, callback) {
   if (callback) {
-    this.once('notify', function() {
-      callback(null);
+    this.once('notify', function(state) {
+      callback(null, state);
     });
   }
 


### PR DESCRIPTION
The notification state is being emitted by the `Noble` object [here](https://github.com/sandeepmistry/noble/blob/a7837885e520578a64294e249e44a96f891624f1/lib/noble.js#L326), but it is not sent through to the `notify` callback.
