### PR TITLE
fix serviceUuids var check in peripheral-explorer.js

### DIFF
--- a/examples/peripheral-explorer.js
+++ b/examples/peripheral-explorer.js
@@ -40,7 +40,7 @@ noble.on('discover', function(peripheral) {
       console.log('  Service Data      = ' + serviceData);
     }
 
-    if (localName) {
+    if (serviceUuids) {
       console.log('  Service UUIDs     = ' + serviceUuids);
     }
 


### PR DESCRIPTION
it was previously using localName to check.