### PR TITLE
Check for changes to scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,17 @@ noble.on('stateChange', callback(state));
 
 #### Scan started:
 
+This callback is called once scanning has started. It can also be called
+if some other application enables BLE scanning.
+
 ```javascript
 noble.on('scanStart', callback);
 ```
 
 #### Scan stopped
+
+This callback is called when scanning is stopped. It can also be called
+if a different application stops scanning or changes the scanning parameters.
 
 ```javascript
 noble.on('scanStop', callback);

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -7,18 +7,22 @@ var Gap = function(hci) {
   this._hci = hci;
 
   this._scanState = null;
+  this._scanFilterDuplicates = null;
   this._discoveries = {};
 
   this._hci.on('error', this.onHciError.bind(this));
   this._hci.on('leScanParametersSet', this.onHciLeScanParametersSet.bind(this));
   this._hci.on('leScanEnableSet', this.onHciLeScanEnableSet.bind(this));
   this._hci.on('leAdvertisingReport', this.onHciLeAdvertisingReport.bind(this));
+
+  this._hci.on('cmdLeScanEnableSet', this.onCmdHciLeScanEnableSet.bind(this));
 };
 
 util.inherits(Gap, events.EventEmitter);
 
 Gap.prototype.startScanning = function(allowDuplicates) {
   this._scanState = 'starting';
+  this._scanFilterDuplicates = !allowDuplicates;
 
   this._hci.setScanEnabled(true, !allowDuplicates);
 };
@@ -37,15 +41,41 @@ Gap.prototype.onHciLeScanParametersSet = function() {
 
 };
 
-Gap.prototype.onHciLeScanEnableSet = function() {
+// Called when receive an event "Command Complete" for "LE Set Scan Enable"
+Gap.prototype.onHciLeScanEnableSet = function(status) {
+  // Check the status we got from the command complete function.
+  // If it is nonzero there was an error, and we should not change
+  // our status as a result.
+  if (status != 0) {
+    return;
+  }
+
   if (this._scanState === 'starting') {
-    this._scanState = 'stared';
+    this._scanState = 'started';
 
     this.emit('scanStart');
   } else if (this._scanState === 'stopping') {
     this._scanState = 'stopped';
 
     this.emit('scanStop');
+  }
+};
+
+// Called when we see the actual command "LE Set Scan Enable"
+Gap.prototype.onCmdHciLeScanEnableSet = function(enable, filter_dups) {
+  // Check to see if the new settings differ from what we expect.
+  // If we are scanning, then a change happens if the new command stops
+  // scanning or if duplicate filtering changes.
+  // If we are not scanning, then a change happens if scanning was enabled.
+  if ((this._scanState == 'starting' || this._scanState == 'started') &&
+      (!enable || this._scanFilterDuplicates != filter_dups)) {
+    // We think we are scanning with particular settings and these changed.
+    // Notify the user that scanning may have stopped.
+    this.emit('scanStop');
+  } else if ((this._scanState == 'stopping' || this._scanState == 'stopped') &&
+             (enable)) {
+    // Someone started scanning on us.
+    this.emit('scanStart');
   }
 };
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -116,7 +116,7 @@ Hci.prototype.pollIsDevUp = function() {
 
 Hci.prototype.setSocketFilter = function() {
   var filter = new Buffer(14);
-  var typeMask = (1 << HCI_EVENT_PKT)| (1 << HCI_ACLDATA_PKT);
+  var typeMask = (1 << HCI_EVENT_PKT) | (1 << HCI_ACLDATA_PKT) | (1 << HCI_COMMAND_PKT);
   var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
   var eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
   var opcode = 0;
@@ -468,6 +468,23 @@ Hci.prototype.onSocketData = function(data) {
         delete this._handleBuffers[handle];
       }
     }
+  } else if (HCI_COMMAND_PKT === eventType) {
+    cmd = data.readUInt16LE(1);
+    var len = data.readUInt8(3);
+
+    debug('\t\tcmd = ' + cmd);
+    debug('\t\tdata len = ' + len);
+
+    if (cmd === LE_SET_SCAN_ENABLE_CMD) {
+      var enable = (data.readUInt8(4) === 0x1);
+      var filter_dups = (data.readUInt8(5) === 0x1);
+
+      debug('\t\t\tLE enable scan command');
+      debug('\t\t\tenable scanning = ' + enable);
+      debug('\t\t\tfilter duplicates = ' + filter_dups);
+
+      this.emit('cmdLeScanEnableSet', enable, filter_dups);
+    }
   }
 };
 
@@ -515,7 +532,7 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
 
     this.emit('leScanParametersSet');
   } else if (cmd === LE_SET_SCAN_ENABLE_CMD) {
-    this.emit('leScanEnableSet');
+    this.emit('leScanEnableSet', status);
   } else if (cmd === READ_RSSI_CMD) {
     var handle = result.readUInt16LE(0);
     var rssi = result.readInt8(2);


### PR DESCRIPTION
This adds receiving HCI CMD packets and checking to see if they are scan enable commands. If they are, it checks to see if scan enable/disable and duplicate filtering settings are different then what the current script expects. If they are, a callback is issued so that the main script can take any necessary action.

Pull request for issue #300.