### PR TITLE
(mostly) replace peripheralUuid with peripheralId

### DIFF
--- a/lib/distributed/bindings.js
+++ b/lib/distributed/bindings.js
@@ -157,8 +157,8 @@ NobleBindings.prototype.stopScanning = function() {
   this.emit('scanStop');
 };
 
-NobleBindings.prototype.connect = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.connect = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'connect',
@@ -166,8 +166,8 @@ NobleBindings.prototype.connect = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.disconnect = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.disconnect = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'disconnect',
@@ -175,8 +175,8 @@ NobleBindings.prototype.disconnect = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.updateRssi = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.updateRssi = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'updateRssi',
@@ -184,8 +184,8 @@ NobleBindings.prototype.updateRssi = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverServices = function(peripheralId, uuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverServices',
@@ -194,8 +194,8 @@ NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
   });
 };
 
-NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverIncludedServices',
@@ -205,8 +205,8 @@ NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceU
   });
 };
 
-NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverCharacteristics',
@@ -216,8 +216,8 @@ NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceUu
   });
 };
 
-NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.read = function(peripheralId, serviceUuid, characteristicUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'read',
@@ -227,8 +227,8 @@ NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicU
   });
 };
 
-NobleBindings.prototype.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'write',
@@ -240,8 +240,8 @@ NobleBindings.prototype.write = function(deviceUuid, serviceUuid, characteristic
   });
 };
 
-NobleBindings.prototype.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'broadcast',
@@ -252,8 +252,8 @@ NobleBindings.prototype.broadcast = function(deviceUuid, serviceUuid, characteri
   });
 };
 
-NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'notify',
@@ -264,8 +264,8 @@ NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristi
   });
 };
 
-NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverDescriptors',
@@ -275,8 +275,8 @@ NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceUuid, 
   });
 };
 
-NobleBindings.prototype.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'readValue',
@@ -287,8 +287,8 @@ NobleBindings.prototype.readValue = function(deviceUuid, serviceUuid, characteri
   });
 };
 
-NobleBindings.prototype.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'writeValue',
@@ -300,8 +300,8 @@ NobleBindings.prototype.writeValue = function(deviceUuid, serviceUuid, character
   });
 };
 
-NobleBindings.prototype.readHandle = function(deviceUuid, handle) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.readHandle = function(peripheralId, handle) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'readHandle',
@@ -310,8 +310,8 @@ NobleBindings.prototype.readHandle = function(deviceUuid, handle) {
   });
 };
 
-NobleBindings.prototype.writeHandle = function(deviceUuid, handle, data, withoutResponse) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.writeHandle = function(peripheralId, handle, data, withoutResponse) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand(peripheral.ws, {
     action: 'readHandle',

--- a/lib/distributed/bindings.js
+++ b/lib/distributed/bindings.js
@@ -53,7 +53,7 @@ NobleBindings.prototype._onClose = function(ws) {
 
 NobleBindings.prototype._onMessage = function(ws, event) {
   var type = event.type;
-  var peripheralUuid = event.peripheralUuid;
+  var peripheralId = event.peripheralUuid;
   var address = event.address;
   var addressType = event.addressType;
   var connectable = event.connectable;
@@ -80,48 +80,48 @@ NobleBindings.prototype._onMessage = function(ws, event) {
       serviceData: (advertisement.serviceData ? new Buffer(advertisement.serviceData, 'hex') : null)
     };
 
-    // TODO: handle duplicate peripheralUuid's
-    this._peripherals[peripheralUuid] = {
-      uuid: peripheralUuid,
+    // TODO: handle duplicate peripheralId's
+    this._peripherals[peripheralId] = {
+      uuid: peripheralId,
       address: address,
       advertisement: advertisement,
       rssi: rssi,
       ws: ws
     };
 
-    this.emit('discover', peripheralUuid, address, addressType, connectable, advertisement, rssi);
+    this.emit('discover', peripheralId, address, addressType, connectable, advertisement, rssi);
   } else if (type === 'connect') {
-    this.emit('connect', peripheralUuid);
+    this.emit('connect', peripheralId);
   } else if (type === 'disconnect') {
-    this.emit('disconnect', peripheralUuid);
+    this.emit('disconnect', peripheralId);
   } else if (type === 'rssiUpdate') {
-    this.emit('rssiUpdate', peripheralUuid, rssi);
+    this.emit('rssiUpdate', peripheralId, rssi);
   } else if (type === 'servicesDiscover') {
-    this.emit('servicesDiscover', peripheralUuid, serviceUuids);
+    this.emit('servicesDiscover', peripheralId, serviceUuids);
   } else if (type === 'includedServicesDiscover') {
-    this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+    this.emit('includedServicesDiscover', peripheralId, serviceUuid, includedServiceUuids);
   } else if (type === 'characteristicsDiscover') {
-    this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+    this.emit('characteristicsDiscover', peripheralId, serviceUuid, characteristics);
   } else if (type === 'read') {
-    this.emit('read', peripheralUuid, serviceUuid, characteristicUuid, data, isNotification);
+    this.emit('read', peripheralId, serviceUuid, characteristicUuid, data, isNotification);
   } else if (type === 'write') {
-    this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralId, serviceUuid, characteristicUuid);
   } else if (type === 'broadcast') {
-    this.emit('broadcast', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('broadcast', peripheralId, serviceUuid, characteristicUuid, state);
   } else if (type === 'notify') {
-    this.emit('notify', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('notify', peripheralId, serviceUuid, characteristicUuid, state);
   } else if (type === 'descriptorsDiscover') {
-    this.emit('descriptorsDiscover', peripheralUuid, serviceUuid, characteristicUuid, descriptors);
+    this.emit('descriptorsDiscover', peripheralId, serviceUuid, characteristicUuid, descriptors);
   } else if (type === 'valueRead') {
-    this.emit('valueRead', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+    this.emit('valueRead', peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data);
   } else if (type === 'valueWrite') {
-    this.emit('valueWrite', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+    this.emit('valueWrite', peripheralId, serviceUuid, characteristicUuid, descriptorUuid);
   } else if (type === 'handleRead') {
-    this.emit('handleRead', peripheralUuid, handle, data);
+    this.emit('handleRead', peripheralId, handle, data);
   } else if (type === 'handleWrite') {
-    this.emit('handleWrite', peripheralUuid, handle);
+    this.emit('handleWrite', peripheralId, handle);
   } else if (type === 'handleNotify') {
-    this.emit('handleNotify', peripheralUuid, handle, data);
+    this.emit('handleNotify', peripheralId, handle, data);
   }
 };
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -40,25 +40,25 @@ NobleBindings.prototype.stopScanning = function() {
   this._gap.stopScanning();
 };
 
-NobleBindings.prototype.connect = function(peripheralUuid) {
-  var address = this._addresses[peripheralUuid];
-  var addressType = this._addresseTypes[peripheralUuid];
+NobleBindings.prototype.connect = function(peripheralId) {
+  var address = this._addresses[peripheralId];
+  var addressType = this._addresseTypes[peripheralId];
 
   if (!this._pendingConnectionUuid) {
-    this._pendingConnectionUuid = peripheralUuid;
+    this._pendingConnectionUuid = peripheralId;
 
     this._hci.createLeConn(address, addressType);
   } else {
-    this._connectionQueue.push(peripheralUuid);
+    this._connectionQueue.push(peripheralId);
   }
 };
 
-NobleBindings.prototype.disconnect = function(peripheralUuid) {
-  this._hci.disconnect(this._handles[peripheralUuid]);
+NobleBindings.prototype.disconnect = function(peripheralId) {
+  this._hci.disconnect(this._handles[peripheralId]);
 };
 
-NobleBindings.prototype.updateRssi = function(peripheralUuid) {
-  this._hci.readRssi(this._handles[peripheralUuid]);
+NobleBindings.prototype.updateRssi = function(peripheralId) {
+  this._hci.readRssi(this._handles[peripheralId]);
 };
 
 NobleBindings.prototype.init = function() {
@@ -212,12 +212,12 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
   this.emit('connect', uuid, error);
 
   if (this._connectionQueue.length > 0) {
-    var peripheralUuid = this._connectionQueue.shift();
+    var peripheralId = this._connectionQueue.shift();
 
-    address = this._addresses[peripheralUuid];
-    addressType = this._addresseTypes[peripheralUuid];
+    address = this._addresses[peripheralId];
+    addressType = this._addresseTypes[peripheralId];
 
-    this._pendingConnectionUuid = peripheralUuid;
+    this._pendingConnectionUuid = peripheralId;
 
     this._hci.createLeConn(address, addressType);
   } else {
@@ -274,14 +274,14 @@ NobleBindings.prototype.onAclDataPkt = function(handle, cid, data) {
 };
 
 
-NobleBindings.prototype.discoverServices = function(peripheralUuid, uuids) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.discoverServices = function(peripheralId, uuids) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.discoverServices(uuids || []);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -291,14 +291,14 @@ NobleBindings.prototype.onServicesDiscovered = function(address, serviceUuids) {
   this.emit('servicesDiscover', uuid, serviceUuids);
 };
 
-NobleBindings.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.discoverIncludedServices(serviceUuid, serviceUuids || []);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -308,14 +308,14 @@ NobleBindings.prototype.onIncludedServicesDiscovered = function(address, service
   this.emit('includedServicesDiscover', uuid, serviceUuid, includedServiceUuids);
 };
 
-NobleBindings.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.discoverCharacteristics(serviceUuid, characteristicUuids || []);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -325,14 +325,14 @@ NobleBindings.prototype.onCharacteristicsDiscovered = function(address, serviceU
   this.emit('characteristicsDiscover', uuid, serviceUuid, characteristics);
 };
 
-NobleBindings.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.read = function(peripheralId, serviceUuid, characteristicUuid) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.read(serviceUuid, characteristicUuid);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -342,14 +342,14 @@ NobleBindings.prototype.onRead = function(address, serviceUuid, characteristicUu
   this.emit('read', uuid, serviceUuid, characteristicUuid, data, false);
 };
 
-NobleBindings.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.write(serviceUuid, characteristicUuid, data, withoutResponse);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -359,14 +359,14 @@ NobleBindings.prototype.onWrite = function(address, serviceUuid, characteristicU
   this.emit('write', uuid, serviceUuid, characteristicUuid);
 };
 
-NobleBindings.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.broadcast(serviceUuid, characteristicUuid, broadcast);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -376,14 +376,14 @@ NobleBindings.prototype.onBroadcast = function(address, serviceUuid, characteris
   this.emit('broadcast', uuid, serviceUuid, characteristicUuid, state);
 };
 
-NobleBindings.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.notify(serviceUuid, characteristicUuid, notify);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -399,14 +399,14 @@ NobleBindings.prototype.onNotification = function(address, serviceUuid, characte
   this.emit('read', uuid, serviceUuid, characteristicUuid, data, true);
 };
 
-NobleBindings.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.discoverDescriptors(serviceUuid, characteristicUuid);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -416,14 +416,14 @@ NobleBindings.prototype.onDescriptorsDiscovered = function(address, serviceUuid,
   this.emit('descriptorsDiscover', uuid, serviceUuid, characteristicUuid, descriptorUuids);
 };
 
-NobleBindings.prototype.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.readValue(serviceUuid, characteristicUuid, descriptorUuid);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -433,14 +433,14 @@ NobleBindings.prototype.onValueRead = function(address, serviceUuid, characteris
   this.emit('valueRead', uuid, serviceUuid, characteristicUuid, descriptorUuid, data);
 };
 
-NobleBindings.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.writeValue(serviceUuid, characteristicUuid, descriptorUuid, data);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -450,14 +450,14 @@ NobleBindings.prototype.onValueWrite = function(address, serviceUuid, characteri
   this.emit('valueWrite', uuid, serviceUuid, characteristicUuid, descriptorUuid);
 };
 
-NobleBindings.prototype.readHandle = function(peripheralUuid, attHandle) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.readHandle = function(peripheralId, attHandle) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.readHandle(attHandle);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 
@@ -467,14 +467,14 @@ NobleBindings.prototype.onHandleRead = function(address, handle, data) {
   this.emit('handleRead', uuid, handle, data);
 };
 
-NobleBindings.prototype.writeHandle = function(peripheralUuid, attHandle, data, withoutResponse) {
-  var handle = this._handles[peripheralUuid];
+NobleBindings.prototype.writeHandle = function(peripheralId, attHandle, data, withoutResponse) {
+  var handle = this._handles[peripheralId];
   var gatt = this._gatts[handle];
 
   if (gatt) {
     gatt.writeHandle(attHandle, data, withoutResponse);
   } else {
-    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+    console.warn('noble warning: unknown peripheral ' + peripheralId);
   }
 };
 

--- a/lib/mac/legacy.js
+++ b/lib/mac/legacy.js
@@ -128,7 +128,7 @@ nobleBindings.stopScanning = function() {
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId13' : 'kCBMsgId31', function(args) {
-  var peripheralUuid = args.kCBMsgArgPeripheral.kCBMsgArgUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgPeripheral.kCBMsgArgUUID.toString('hex');
   var peripheralHandle = args.kCBMsgArgPeripheral.kCBMsgArgPeripheralHandle;
   var advertisement = {
     localName: args.kCBMsgArgAdvertisementData.kCBAdvDataLocalName,
@@ -159,10 +159,10 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId13' : 'kCBMsgId31', function(args) 
     }
   }
 
-  debug('peripheral ' + peripheralUuid + ' discovered');
+  debug('peripheral ' + peripheralId + ' discovered');
 
-  this._peripherals[peripheralUuid] = this._peripherals[peripheralHandle] = {
-    uuid: peripheralUuid,
+  this._peripherals[peripheralId] = this._peripherals[peripheralHandle] = {
+    uuid: peripheralId,
     address: undefined,
     addressType: undefined,
     handle: peripheralHandle,
@@ -170,73 +170,73 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId13' : 'kCBMsgId31', function(args) 
     rssi: rssi
   };
 
-  (function(peripheralUuid, peripheralHandle, advertisement, rssi) {
-    uuidToAddress(peripheralUuid, function(error, address, addressType) {
+  (function(peripheralId, peripheralHandle, advertisement, rssi) {
+    uuidToAddress(peripheralId, function(error, address, addressType) {
       address = address || 'unknown';
       addressType = addressType || 'unknown';
 
-      this._peripherals[peripheralUuid].address = this._peripherals[peripheralHandle].address = address;
-      this._peripherals[peripheralUuid].addressType = this._peripherals[peripheralHandle].addressType = addressType;
+      this._peripherals[peripheralId].address = this._peripherals[peripheralHandle].address = address;
+      this._peripherals[peripheralId].addressType = this._peripherals[peripheralHandle].addressType = addressType;
 
-      this.emit('discover', peripheralUuid, address, addressType, undefined, advertisement, rssi);
+      this.emit('discover', peripheralId, address, addressType, undefined, advertisement, rssi);
     }.bind(this));
-  }.bind(this))(peripheralUuid, peripheralHandle, advertisement, rssi);
+  }.bind(this))(peripheralId, peripheralHandle, advertisement, rssi);
 });
 
-nobleBindings.connect = function(peripheralUuid) {
+nobleBindings.connect = function(peripheralId) {
   this.sendCBMsg(isLessThan10_8_5 ? 9 : 25, {
     kCBMsgArgOptions: {
       kCBConnectOptionNotifyOnDisconnection: 1
     },
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId14' : 'kCBMsgId32', function(args) {
-  var peripheralUuid = args.kCBMsgArgUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgUUID.toString('hex');
   // var peripheralHandle = args.kCBMsgArgPeripheralHandle;
 
-  debug('peripheral ' + peripheralUuid + ' connected');
+  debug('peripheral ' + peripheralId + ' connected');
 
-  this.emit('connect', peripheralUuid);
+  this.emit('connect', peripheralId);
 });
 
-nobleBindings.disconnect = function(peripheralUuid) {
+nobleBindings.disconnect = function(peripheralId) {
   this.sendCBMsg(isLessThan10_8_5 ? 10 : 26, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId15' : 'kCBMsgId33', function(args) {
-  var peripheralUuid = args.kCBMsgArgUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgUUID.toString('hex');
   // var peripheralHandle = args.kCBMsgArgPeripheralHandle;
 
-  debug('peripheral ' + peripheralUuid + ' disconnected');
+  debug('peripheral ' + peripheralId + ' disconnected');
 
-  this.emit('disconnect', peripheralUuid);
+  this.emit('disconnect', peripheralId);
 });
 
-nobleBindings.updateRssi = function(peripheralUuid) {
+nobleBindings.updateRssi = function(peripheralId) {
   this.sendCBMsg(isLessThan10_8_5 ? 16 : 35, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId20' : 'kCBMsgId41', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var rssi = args.kCBMsgArgData;
 
   this._peripherals[peripheralHandle].rssi = rssi;
 
-  debug('peripheral ' + peripheralUuid + ' RSSI update ' + rssi);
+  debug('peripheral ' + peripheralId + ' RSSI update ' + rssi);
 
-  this.emit('rssiUpdate', peripheralUuid, rssi);
+  this.emit('rssiUpdate', peripheralId, rssi);
 });
 
-nobleBindings.discoverServices = function(peripheralUuid, uuids) {
+nobleBindings.discoverServices = function(peripheralId, uuids) {
   var args = {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
     kCBMsgArgUUIDs: []
   };
 
@@ -251,7 +251,7 @@ nobleBindings.discoverServices = function(peripheralUuid, uuids) {
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId21' : 'kCBMsgId42', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var serviceUuids = [];
 
   this._peripherals[peripheralHandle].services = {};
@@ -268,14 +268,14 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId21' : 'kCBMsgId42', function(args) 
     serviceUuids.push(service.uuid);
   }
 
-  this.emit('servicesDiscover', peripheralUuid, serviceUuids);
+  this.emit('servicesDiscover', peripheralId, serviceUuids);
 });
 
-nobleBindings.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
   var args = {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceUuid].endHandle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -289,14 +289,14 @@ nobleBindings.discoverIncludedServices = function(peripheralUuid, serviceUuid, s
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId27' : 'kCBMsgId48', function(args) {
-  var peripheralUuidHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralUuidHandle].uuid;
+  var peripheralIdHandle = args.kCBMsgArgPeripheralHandle;
+  var peripheralId = this._peripherals[peripheralIdHandle].uuid;
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[peripheralUuidHandle].services[serviceStartHandle].uuid;
+  var serviceUuid = this._peripherals[peripheralIdHandle].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices = {};
+  this._peripherals[peripheralIdHandle].services[serviceStartHandle].includedServices = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -305,20 +305,20 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId27' : 'kCBMsgId48', function(args) 
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[peripheralIdHandle].services[serviceStartHandle].includedServices[includedServices.uuid] =
+      this._peripherals[peripheralIdHandle].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
 
     includedServiceUuids.push(includedService.uuid);
   }
 
-  this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', peripheralId, serviceUuid, includedServiceUuids);
 });
 
-nobleBindings.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
   var args = {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceUuid].endHandle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -333,7 +333,7 @@ nobleBindings.discoverCharacteristics = function(peripheralUuid, serviceUuid, ch
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId28' : 'kCBMsgId49', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
   var serviceUuid = this._peripherals[peripheralHandle].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
@@ -393,14 +393,14 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId28' : 'kCBMsgId49', function(args) 
     });
   }
 
-  this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', peripheralId, serviceUuid, characteristics);
 });
 
-nobleBindings.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(isLessThan10_8_5 ? 29 : 50 , {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
@@ -409,7 +409,7 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId35' : 'kCBMsgId56', function(args) 
   var peripheral = this._peripherals[peripheralHandle];
 
   if (peripheral) {
-    var peripheralUuid = peripheral.uuid;
+    var peripheralId = peripheral.uuid;
     var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
     var isNotification = args.kCBMsgArgIsNotification ? true : false;
     var data = args.kCBMsgArgData;
@@ -418,7 +418,7 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId35' : 'kCBMsgId56', function(args) 
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', peripheralUuid, peripheral.services[i].uuid,
+        this.emit('read', peripheralId, peripheral.services[i].uuid,
           peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
         break;
       }
@@ -428,48 +428,48 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId35' : 'kCBMsgId56', function(args) 
   }
 });
 
-nobleBindings.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
   this.sendCBMsg(isLessThan10_8_5 ? 30 : 51, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralId, serviceUuid, characteristicUuid);
   }
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId36' : 'kCBMsgId57', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+      this.emit('write', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid);
       break;
     }
   }
 });
 
-nobleBindings.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
   this.sendCBMsg(isLessThan10_8_5 ? 31 : 52, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId37' : 'kCBMsgId58', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
@@ -477,25 +477,25 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId37' : 'kCBMsgId58', function(args) 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+      this.emit('broadcast', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
 });
 
-nobleBindings.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
   this.sendCBMsg(isLessThan10_8_5 ? 32 : 53, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId38' : 'kCBMsgId59', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
@@ -503,24 +503,24 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId38' : 'kCBMsgId59', function(args) 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+      this.emit('notify', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
 });
 
-nobleBindings.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(isLessThan10_8_5 ? 34 : 55, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId39' : 'kCBMsgId60', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var descriptors = []; //args.kCBMsgArgDescriptors;
@@ -543,35 +543,35 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId39' : 'kCBMsgId60', function(args) 
         descriptors.push(descriptor.uuid);
       }
 
-      this.emit('descriptorsDiscover', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+      this.emit('descriptorsDiscover', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, descriptors);
       break;
     }
   }
 });
 
-nobleBindings.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
   this.sendCBMsg(isLessThan10_8_5 ? 40 : 61, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId42' : 'kCBMsgId63', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
   var data = args.kCBMsgArgData;
 
-  this.emit('handleRead', peripheralUuid, descriptorHandle, data);
+  this.emit('handleRead', peripheralId, descriptorHandle, data);
 
   for(var i in this._peripherals[peripheralHandle].services) {
     for(var j in this._peripherals[peripheralHandle].services[i].characteristics) {
       if (this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors &&
         this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+        this.emit('valueRead', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
           this._peripherals[peripheralHandle].services[i].characteristics[j].uuid,
           this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
         return; // break;
@@ -580,28 +580,28 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId42' : 'kCBMsgId63', function(args) 
   }
 });
 
-nobleBindings.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
   this.sendCBMsg(isLessThan10_8_5 ? 41 : 62, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
     kCBMsgArgData: data
   });
 };
 
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId43' : 'kCBMsgId64', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
-  var peripheralUuid = this._peripherals[peripheralHandle].uuid;
+  var peripheralId = this._peripherals[peripheralHandle].uuid;
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
 
-  this.emit('handleWrite', peripheralUuid, descriptorHandle);
+  this.emit('handleWrite', peripheralId, descriptorHandle);
 
   for(var i in this._peripherals[peripheralHandle].services) {
     for(var j in this._peripherals[peripheralHandle].services[i].characteristics) {
       if (this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors &&
         this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
+        this.emit('valueWrite', peripheralId, this._peripherals[peripheralHandle].services[i].uuid,
           this._peripherals[peripheralHandle].services[i].characteristics[j].uuid,
           this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
         return; // break;
@@ -610,17 +610,17 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId43' : 'kCBMsgId64', function(args) 
   }
 });
 
-nobleBindings.readHandle = function(peripheralUuid, handle) {
+nobleBindings.readHandle = function(peripheralId, handle) {
   this.sendCBMsg(isLessThan10_8_5 ? 40 : 61, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
     kCBMsgArgDescriptorHandle: handle
   });
 };
 
-nobleBindings.writeHandle = function(peripheralUuid, handle, data, withoutResponse) {
+nobleBindings.writeHandle = function(peripheralId, handle, data, withoutResponse) {
   // TODO: use without response
   this.sendCBMsg(isLessThan10_8_5 ? 41 : 62, {
-    kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
+    kCBMsgArgPeripheralHandle: this._peripherals[peripheralId].handle,
     kCBMsgArgDescriptorHandle: handle,
     kCBMsgArgData: data
   });

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -108,7 +108,7 @@ nobleBindings.on('kCBMsgId37', function(args) {
     return;
   }
 
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var advertisement = {
     localName: args.kCBMsgArgAdvertisementData.kCBAdvDataLocalName || args.kCBMsgArgName,
     txPowerLevel: args.kCBMsgArgAdvertisementData.kCBAdvDataTxPowerLevel,
@@ -138,82 +138,82 @@ nobleBindings.on('kCBMsgId37', function(args) {
     }
   }
 
-  debug('peripheral ' + deviceUuid + ' discovered');
+  debug('peripheral ' + peripheralId + ' discovered');
 
-  var uuid = new Buffer(deviceUuid, 'hex');
+  var uuid = new Buffer(peripheralId, 'hex');
   uuid.isUuid = true;
 
-  if(!this._peripherals[deviceUuid]) {
-    this._peripherals[deviceUuid] = {};
+  if(!this._peripherals[peripheralId]) {
+    this._peripherals[peripheralId] = {};
   }
-  this._peripherals[deviceUuid].uuid = uuid;
-  this._peripherals[deviceUuid].advertisement = advertisement;
-  this._peripherals[deviceUuid].rssi = rssi;
+  this._peripherals[peripheralId].uuid = uuid;
+  this._peripherals[peripheralId].advertisement = advertisement;
+  this._peripherals[peripheralId].rssi = rssi;
 
-  (function(deviceUuid, advertisement, rssi) {
-    uuidToAddress(deviceUuid, function(error, address, addressType) {
+  (function(peripheralId, advertisement, rssi) {
+    uuidToAddress(peripheralId, function(error, address, addressType) {
       address = address || 'unknown';
       addressType = addressType || 'unknown';
 
-      this._peripherals[deviceUuid].address = address;
-      this._peripherals[deviceUuid].addressType = addressType;
+      this._peripherals[peripheralId].address = address;
+      this._peripherals[peripheralId].addressType = addressType;
 
-      this.emit('discover', deviceUuid, address, addressType, undefined, advertisement, rssi);
+      this.emit('discover', peripheralId, address, addressType, undefined, advertisement, rssi);
     }.bind(this));
-  }.bind(this))(deviceUuid, advertisement, rssi);
+  }.bind(this))(peripheralId, advertisement, rssi);
 });
 
-nobleBindings.connect = function(deviceUuid) {
+nobleBindings.connect = function(peripheralId) {
   this.sendCBMsg(31, {
     kCBMsgArgOptions: {
       kCBConnectOptionNotifyOnDisconnection: 1
     },
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
 nobleBindings.on('kCBMsgId38', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
 
-  debug('peripheral ' + deviceUuid + ' connected');
+  debug('peripheral ' + peripheralId + ' connected');
 
-  this.emit('connect', deviceUuid);
+  this.emit('connect', peripheralId);
 });
 
-nobleBindings.disconnect = function(deviceUuid) {
+nobleBindings.disconnect = function(peripheralId) {
   this.sendCBMsg(32, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
 nobleBindings.on('kCBMsgId40', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
 
-  debug('peripheral ' + deviceUuid + ' disconnected');
+  debug('peripheral ' + peripheralId + ' disconnected');
 
-  this.emit('disconnect', deviceUuid);
+  this.emit('disconnect', peripheralId);
 });
 
-nobleBindings.updateRssi = function(deviceUuid) {
+nobleBindings.updateRssi = function(peripheralId) {
   this.sendCBMsg(43, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
 nobleBindings.on('kCBMsgId54', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var rssi = args.kCBMsgArgData;
 
-  this._peripherals[deviceUuid].rssi = rssi;
+  this._peripherals[peripheralId].rssi = rssi;
 
-  debug('peripheral ' + deviceUuid + ' RSSI update ' + rssi);
+  debug('peripheral ' + peripheralId + ' RSSI update ' + rssi);
 
-  this.emit('rssiUpdate', deviceUuid, rssi);
+  this.emit('rssiUpdate', peripheralId, rssi);
 });
 
-nobleBindings.discoverServices = function(deviceUuid, uuids) {
+nobleBindings.discoverServices = function(peripheralId, uuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgUUIDs: []
   };
 
@@ -227,10 +227,10 @@ nobleBindings.discoverServices = function(deviceUuid, uuids) {
 };
 
 nobleBindings.on('kCBMsgId55', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  this._peripherals[peripheralId].services = {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -240,21 +240,21 @@ nobleBindings.on('kCBMsgId55', function(args) {
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      this._peripherals[peripheralId].services[service.uuid] = this._peripherals[peripheralId].services[service.startHandle] = service;
 
       serviceUuids.push(service.uuid);
     }
   }
   // TODO: result 24 => device not connected
 
-  this.emit('servicesDiscover', deviceUuid, serviceUuids);
+  this.emit('servicesDiscover', peripheralId, serviceUuids);
 });
 
-nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -268,13 +268,13 @@ nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, servi
 };
 
 nobleBindings.on('kCBMsgId62', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
+  var serviceUuid = this._peripherals[peripheralId].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
+  this._peripherals[peripheralId].services[serviceStartHandle].includedServices = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -283,20 +283,20 @@ nobleBindings.on('kCBMsgId62', function(args) {
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[peripheralId].services[serviceStartHandle].includedServices[includedServices.uuid] =
+      this._peripherals[peripheralId].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
 
     includedServiceUuids.push(includedService.uuid);
   }
 
-  this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', peripheralId, serviceUuid, includedServiceUuids);
 });
 
-nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -310,13 +310,13 @@ nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, charac
 };
 
 nobleBindings.on('kCBMsgId63', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
+  var serviceUuid = this._peripherals[peripheralId].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  this._peripherals[peripheralId].services[serviceStartHandle].characteristics = {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
@@ -360,9 +360,9 @@ nobleBindings.on('kCBMsgId63', function(args) {
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
+    this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.uuid] =
+      this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.handle] =
+      this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
 
     characteristics.push({
       uuid: characteristic.uuid,
@@ -370,138 +370,138 @@ nobleBindings.on('kCBMsgId63', function(args) {
     });
   }
 
-  this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', peripheralId, serviceUuid, characteristics);
 });
 
-nobleBindings.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(64 , {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
 nobleBindings.on('kCBMsgId70', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var isNotification = args.kCBMsgArgIsNotification ? true : false;
   var data = args.kCBMsgArgData;
 
-  var peripheral = this._peripherals[deviceUuid];
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     for(var i in peripheral.services) {
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', deviceUuid, peripheral.services[i].uuid,
+        this.emit('read', peripheralId, peripheral.services[i].uuid,
           peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
         break;
       }
     }
   } else {
-    console.warn('noble (mac mavericks): received read event from unknown peripheral: ' + deviceUuid + ' !');
+    console.warn('noble (mac mavericks): received read event from unknown peripheral: ' + peripheralId + ' !');
   }
 });
 
-nobleBindings.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
   this.sendCBMsg(65, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralId, serviceUuid, characteristicUuid);
   }
 };
 
 nobleBindings.on('kCBMsgId71', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('write', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid);
       break;
     }
   }
 });
 
-nobleBindings.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
   this.sendCBMsg(66, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
 
 nobleBindings.on('kCBMsgId72', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('broadcast', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
 });
 
-nobleBindings.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
   this.sendCBMsg(67, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
 
 nobleBindings.on('kCBMsgId73', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('notify', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
 });
 
-nobleBindings.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(69, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
 nobleBindings.on('kCBMsgId75', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var descriptors = []; //args.kCBMsgArgDescriptors;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
 
-      this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors = {};
+      this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors = {};
 
       for(var j = 0; j < args.kCBMsgArgDescriptors.length; j++) {
         var descriptor = {
@@ -509,88 +509,88 @@ nobleBindings.on('kCBMsgId75', function(args) {
           handle: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle
         };
 
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
-          this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
+          this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
 
         descriptors.push(descriptor.uuid);
       }
 
-      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, descriptors);
+      this.emit('descriptorsDiscover', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, descriptors);
       break;
     }
   }
 });
 
-nobleBindings.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
   this.sendCBMsg(76, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
   });
 };
 
 nobleBindings.on('kCBMsgId78', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
   var data = args.kCBMsgArgData;
 
-  this.emit('handleRead', deviceUuid, descriptorHandle, data);
+  this.emit('handleRead', peripheralId, descriptorHandle, data);
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    for(var j in this._peripherals[deviceUuid].services[i].characteristics) {
-      if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
-        this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    for(var j in this._peripherals[peripheralId].services[i].characteristics) {
+      if (this._peripherals[peripheralId].services[i].characteristics[j].descriptors &&
+        this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
+        this.emit('valueRead', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
         return; // break;
       }
     }
   }
 });
 
-nobleBindings.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
   this.sendCBMsg(77, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
     kCBMsgArgData: data
   });
 };
 
 nobleBindings.on('kCBMsgId79', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
 
-  this.emit('handleWrite', deviceUuid, descriptorHandle);
+  this.emit('handleWrite', peripheralId, descriptorHandle);
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    for(var j in this._peripherals[deviceUuid].services[i].characteristics) {
-      if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
-        this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    for(var j in this._peripherals[peripheralId].services[i].characteristics) {
+      if (this._peripherals[peripheralId].services[i].characteristics[j].descriptors &&
+        this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
+        this.emit('valueWrite', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
         return; // break;
       }
     }
   }
 });
 
-nobleBindings.readHandle = function(deviceUuid, handle) {
+nobleBindings.readHandle = function(peripheralId, handle) {
   this.sendCBMsg(76, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgDescriptorHandle: handle
   });
 };
 
-nobleBindings.writeHandle = function(deviceUuid, handle, data, withoutResponse) {
+nobleBindings.writeHandle = function(peripheralId, handle, data, withoutResponse) {
   // TODO: use without response
   this.sendCBMsg(77, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgDescriptorHandle: handle,
     kCBMsgArgData: data
   });

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -132,7 +132,7 @@ nobleBindings.on('kCBMsgId37', function(args) {
     return;
   }
 
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var advertisement = {
     localName: args.kCBMsgArgAdvertisementData.kCBAdvDataLocalName || args.kCBMsgArgName,
     txPowerLevel: args.kCBMsgArgAdvertisementData.kCBAdvDataTxPowerLevel,
@@ -163,31 +163,31 @@ nobleBindings.on('kCBMsgId37', function(args) {
     }
   }
 
-  debug('peripheral ' + deviceUuid + ' discovered');
+  debug('peripheral ' + peripheralId + ' discovered');
 
-  var uuid = new Buffer(deviceUuid, 'hex');
+  var uuid = new Buffer(peripheralId, 'hex');
   uuid.isUuid = true;
 
-  if (!this._peripherals[deviceUuid]) {
-    this._peripherals[deviceUuid] = {};
+  if (!this._peripherals[peripheralId]) {
+    this._peripherals[peripheralId] = {};
   }
 
-  this._peripherals[deviceUuid].uuid = uuid;
-  this._peripherals[deviceUuid].connectable = connectable;
-  this._peripherals[deviceUuid].advertisement = advertisement;
-  this._peripherals[deviceUuid].rssi = rssi;
+  this._peripherals[peripheralId].uuid = uuid;
+  this._peripherals[peripheralId].connectable = connectable;
+  this._peripherals[peripheralId].advertisement = advertisement;
+  this._peripherals[peripheralId].rssi = rssi;
 
-  (function(deviceUuid, advertisement, rssi) {
-    uuidToAddress(deviceUuid, function(error, address, addressType) {
+  (function(peripheralId, advertisement, rssi) {
+    uuidToAddress(peripheralId, function(error, address, addressType) {
       address = address || 'unknown';
       addressType = addressType || 'unknown';
 
-      this._peripherals[deviceUuid].address = address;
-      this._peripherals[deviceUuid].addressType = addressType;
+      this._peripherals[peripheralId].address = address;
+      this._peripherals[peripheralId].addressType = addressType;
 
-      this.emit('discover', deviceUuid, address, addressType, connectable, advertisement, rssi);
+      this.emit('discover', peripheralId, address, addressType, connectable, advertisement, rssi);
     }.bind(this));
-  }.bind(this))(deviceUuid, advertisement, rssi);
+  }.bind(this))(peripheralId, advertisement, rssi);
 });
 
 
@@ -205,25 +205,25 @@ nobleBindings.stopScanning = function() {
 
 /**
  * Connect to peripheral
- * @param  {String} deviceUuid    Peripheral uuid to connect to
+ * @param  {String} peripheralId    Peripheral id to connect to
  *
  * @discussion tested
  */
-nobleBindings.connect = function(deviceUuid) {
+nobleBindings.connect = function(peripheralId) {
   this.sendCBMsg(31, {
     kCBMsgArgOptions: {
       kCBConnectOptionNotifyOnDisconnection: 1
     },
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
 nobleBindings.on('kCBMsgId38', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
 
-  debug('peripheral ' + deviceUuid + ' connected');
+  debug('peripheral ' + peripheralId + ' connected');
 
-  this.emit('connect', deviceUuid);
+  this.emit('connect', peripheralId);
 });
 
 
@@ -231,13 +231,13 @@ nobleBindings.on('kCBMsgId38', function(args) {
 /**
  * Disconnect
  *
- * @param  {String} deviceUuid    Peripheral uuid to disconnect
+ * @param  {String} peripheralId    Peripheral id to disconnect
  *
  * @discussion tested
  */
-nobleBindings.disconnect = function(deviceUuid) {
+nobleBindings.disconnect = function(peripheralId) {
   this.sendCBMsg(32, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
@@ -247,11 +247,11 @@ nobleBindings.disconnect = function(deviceUuid) {
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId40', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
 
-  debug('peripheral ' + deviceUuid + ' disconnected');
+  debug('peripheral ' + peripheralId + ' disconnected');
 
-  this.emit('disconnect', deviceUuid);
+  this.emit('disconnect', peripheralId);
 });
 
 
@@ -261,9 +261,9 @@ nobleBindings.on('kCBMsgId40', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.updateRssi = function(deviceUuid) {
+nobleBindings.updateRssi = function(peripheralId) {
   this.sendCBMsg(44, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid
   });
 };
 
@@ -273,14 +273,14 @@ nobleBindings.updateRssi = function(deviceUuid) {
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId55', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var rssi = args.kCBMsgArgData;
 
-  this._peripherals[deviceUuid].rssi = rssi;
+  this._peripherals[peripheralId].rssi = rssi;
 
-  debug('peripheral ' + deviceUuid + ' RSSI update ' + rssi);
+  debug('peripheral ' + peripheralId + ' RSSI update ' + rssi);
 
-  this.emit('rssiUpdate', deviceUuid, rssi);
+  this.emit('rssiUpdate', peripheralId, rssi);
 });
 
 
@@ -288,14 +288,14 @@ nobleBindings.on('kCBMsgId55', function(args) {
 /**
  * Discover services
  *
- * @param  {String} deviceUuid  Device UUID
+ * @param  {String} peripheralId  peripheral id
  * @param  {Array} uuids        Services to discover, if undefined then all
  *
  * @discussion tested
  */
-nobleBindings.discoverServices = function(deviceUuid, uuids) {
+nobleBindings.discoverServices = function(peripheralId, uuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgUUIDs: []
   };
 
@@ -314,10 +314,10 @@ nobleBindings.discoverServices = function(deviceUuid, uuids) {
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId56', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  this._peripherals[peripheralId].services = {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -327,14 +327,14 @@ nobleBindings.on('kCBMsgId56', function(args) {
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      this._peripherals[peripheralId].services[service.uuid] = this._peripherals[peripheralId].services[service.startHandle] = service;
 
       serviceUuids.push(service.uuid);
     }
   }
   // TODO: result 24 => device not connected
 
-  this.emit('servicesDiscover', deviceUuid, serviceUuids);
+  this.emit('servicesDiscover', peripheralId, serviceUuids);
 });
 
 
@@ -342,17 +342,17 @@ nobleBindings.on('kCBMsgId56', function(args) {
 /**
  * [discoverIncludedServices description]
  *
- * @param  {String} deviceUuid
+ * @param  {String} peripheralId
  * @param  {String} serviceUuid
  * @param  {String} serviceUuids
  *
  * @dicussion tested
  */
-nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -371,13 +371,13 @@ nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, servi
  * @dicussion tested
  */
 nobleBindings.on('kCBMsgId63', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
+  var serviceUuid = this._peripherals[peripheralId].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
+  this._peripherals[peripheralId].services[serviceStartHandle].includedServices = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -386,13 +386,13 @@ nobleBindings.on('kCBMsgId63', function(args) {
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[peripheralId].services[serviceStartHandle].includedServices[includedServices.uuid] =
+      this._peripherals[peripheralId].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
 
     includedServiceUuids.push(includedService.uuid);
   }
 
-  this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', peripheralId, serviceUuid, includedServiceUuids);
 });
 
 
@@ -400,17 +400,17 @@ nobleBindings.on('kCBMsgId63', function(args) {
 /**
  * Discover characteristic
  *
- * @param  {String} deviceUuid          Peripheral UUID
+ * @param  {String} peripheralId          Peripheral Id
  * @param  {String} serviceUuid         Service UUID
  * @param  {Array} characteristicUuids  Characteristics to discover, all if empty
  *
  * @discussion tested
  */
-nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
   var args = {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralId].services[serviceUuid].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralId].services[serviceUuid].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -429,13 +429,13 @@ nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, charac
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId64', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
+  var serviceUuid = this._peripherals[peripheralId].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  this._peripherals[peripheralId].services[serviceStartHandle].characteristics = {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
@@ -479,9 +479,9 @@ nobleBindings.on('kCBMsgId64', function(args) {
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
+    this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.uuid] =
+      this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.handle] =
+      this._peripherals[peripheralId].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
 
     characteristics.push({
       uuid: characteristic.uuid,
@@ -489,7 +489,7 @@ nobleBindings.on('kCBMsgId64', function(args) {
     });
   }
 
-  this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', peripheralId, serviceUuid, characteristics);
 });
 
 
@@ -497,17 +497,17 @@ nobleBindings.on('kCBMsgId64', function(args) {
 /**
  * Read value
  *
- * @param  {[type]} deviceUuid         [description]
+ * @param  {[type]} peripheralId         [description]
  * @param  {[type]} serviceUuid        [description]
  * @param  {[type]} characteristicUuid [description]
  *
  * @discussion tested
  */
-nobleBindings.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(65 , {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
@@ -517,25 +517,25 @@ nobleBindings.read = function(deviceUuid, serviceUuid, characteristicUuid) {
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId71', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var isNotification = args.kCBMsgArgIsNotification ? true : false;
   var data = args.kCBMsgArgData;
 
-  var peripheral = this._peripherals[deviceUuid];
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     for(var i in peripheral.services) {
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', deviceUuid, peripheral.services[i].uuid,
+        this.emit('read', peripheralId, peripheral.services[i].uuid,
           peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
         break;
       }
     }
   } else {
-    console.warn('noble (mac yosemite): received read event from unknown peripheral: ' + deviceUuid + ' !');
+    console.warn('noble (mac yosemite): received read event from unknown peripheral: ' + peripheralId + ' !');
   }
 });
 
@@ -543,7 +543,7 @@ nobleBindings.on('kCBMsgId71', function(args) {
 
 /**
  * Write value
- * @param  {String} deviceUuid
+ * @param  {String} peripheralId
  * @param  {String} serviceUuid
  * @param  {String} characteristicUuid
  * @param  {[Type]} data
@@ -551,17 +551,17 @@ nobleBindings.on('kCBMsgId71', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
   this.sendCBMsg(66, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralId, serviceUuid, characteristicUuid);
   }
 };
 
@@ -571,15 +571,15 @@ nobleBindings.write = function(deviceUuid, serviceUuid, characteristicUuid, data
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId72', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('write', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid);
       break;
     }
   }
@@ -590,7 +590,7 @@ nobleBindings.on('kCBMsgId72', function(args) {
 /**
  * Broadcast
  *
- * @param  {[type]} deviceUuid         [description]
+ * @param  {[type]} peripheralId         [description]
  * @param  {[type]} serviceUuid        [description]
  * @param  {[type]} characteristicUuid [description]
  * @param  {[type]} broadcast          [description]
@@ -598,11 +598,11 @@ nobleBindings.on('kCBMsgId72', function(args) {
  *
  * @discussion The ids were incemented but there seems to be no CoreBluetooth function to call/verify this.
  */
-nobleBindings.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
   this.sendCBMsg(67, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
@@ -613,16 +613,16 @@ nobleBindings.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, 
  * @discussion The ids were incemented but there seems to be no CoreBluetooth function to call/verify this.
  */
 nobleBindings.on('kCBMsgId73', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('broadcast', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
@@ -633,18 +633,18 @@ nobleBindings.on('kCBMsgId73', function(args) {
 /**
  * Register notification hanlder
  *
- * @param  {String} deviceUuid            Peripheral UUID
+ * @param  {String} peripheralId            Peripheral id
  * @param  {String} serviceUuid           Service UUID
  * @param  {String} characteristicUuid    Charactereistic UUID
  * @param  {Bool}   notify                If want to get notification
  *
  * @discussion tested
  */
-nobleBindings.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
   this.sendCBMsg(68, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
@@ -655,16 +655,16 @@ nobleBindings.notify = function(deviceUuid, serviceUuid, characteristicUuid, not
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId74', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var state = args.kCBMsgArgState ? true : false;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
+      this.emit('notify', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, state);
       break;
     }
   }
@@ -675,17 +675,17 @@ nobleBindings.on('kCBMsgId74', function(args) {
 /**
  * Discover service descriptors
  *
- * @param  {String} deviceUuid
+ * @param  {String} peripheralId
  * @param  {String} serviceUuid
  * @param  {String} characteristicUuid
  *
  * @discussion tested
  */
-nobleBindings.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
   this.sendCBMsg(70, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].valueHandle
   });
 };
 
@@ -695,16 +695,16 @@ nobleBindings.discoverDescriptors = function(deviceUuid, serviceUuid, characteri
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId76', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var characteristicHandle = args.kCBMsgArgCharacteristicHandle;
   var result = args.kCBMsgArgResult;
   var descriptors = []; //args.kCBMsgArgDescriptors;
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    if (this._peripherals[deviceUuid].services[i].characteristics &&
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    if (this._peripherals[peripheralId].services[i].characteristics &&
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle]) {
 
-      this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors = {};
+      this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors = {};
 
       for(var j = 0; j < args.kCBMsgArgDescriptors.length; j++) {
         var descriptor = {
@@ -712,14 +712,14 @@ nobleBindings.on('kCBMsgId76', function(args) {
           handle: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle
         };
 
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
-          this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
+          this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
 
         descriptors.push(descriptor.uuid);
       }
 
-      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, descriptors);
+      this.emit('descriptorsDiscover', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+        this._peripherals[peripheralId].services[i].characteristics[characteristicHandle].uuid, descriptors);
       break;
     }
   }
@@ -730,17 +730,17 @@ nobleBindings.on('kCBMsgId76', function(args) {
 /**
  * Read value
  *
- * @param  {[type]} deviceUuid         [description]
+ * @param  {[type]} peripheralId         [description]
  * @param  {[type]} serviceUuid        [description]
  * @param  {[type]} characteristicUuid [description]
  * @param  {[type]} descriptorUuid     [description]
  *
  * @discussion tested
  */
-nobleBindings.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
   this.sendCBMsg(77, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
   });
 };
 
@@ -750,21 +750,21 @@ nobleBindings.readValue = function(deviceUuid, serviceUuid, characteristicUuid, 
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId79', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
   var data = args.kCBMsgArgData;
 
-  this.emit('handleRead', deviceUuid, descriptorHandle, data);
+  this.emit('handleRead', peripheralId, descriptorHandle, data);
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    for(var j in this._peripherals[deviceUuid].services[i].characteristics) {
-      if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
-        this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    for(var j in this._peripherals[peripheralId].services[i].characteristics) {
+      if (this._peripherals[peripheralId].services[i].characteristics[j].descriptors &&
+        this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
+        this.emit('valueRead', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
         return; // break;
       }
     }
@@ -776,7 +776,7 @@ nobleBindings.on('kCBMsgId79', function(args) {
 /**
  * Write value
  *
- * @param  {[type]} deviceUuid         [description]
+ * @param  {[type]} peripheralId         [description]
  * @param  {[type]} serviceUuid        [description]
  * @param  {[type]} characteristicUuid [description]
  * @param  {[type]} descriptorUuid     [description]
@@ -784,10 +784,10 @@ nobleBindings.on('kCBMsgId79', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
   this.sendCBMsg(78, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralId].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
     kCBMsgArgData: data
   });
 };
@@ -798,20 +798,20 @@ nobleBindings.writeValue = function(deviceUuid, serviceUuid, characteristicUuid,
  * @discussion tested
  */
 nobleBindings.on('kCBMsgId80', function(args) {
-  var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
+  var peripheralId = args.kCBMsgArgDeviceUUID.toString('hex');
   var descriptorHandle = args.kCBMsgArgDescriptorHandle;
   var result = args.kCBMsgArgResult;
 
-  this.emit('handleWrite', deviceUuid, descriptorHandle);
+  this.emit('handleWrite', peripheralId, descriptorHandle);
 
-  for(var i in this._peripherals[deviceUuid].services) {
-    for(var j in this._peripherals[deviceUuid].services[i].characteristics) {
-      if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
-        this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
+  for(var i in this._peripherals[peripheralId].services) {
+    for(var j in this._peripherals[peripheralId].services[i].characteristics) {
+      if (this._peripherals[peripheralId].services[i].characteristics[j].descriptors &&
+        this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
+        this.emit('valueWrite', peripheralId, this._peripherals[peripheralId].services[i].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].uuid,
+          this._peripherals[peripheralId].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
         return; // break;
       }
     }
@@ -823,14 +823,14 @@ nobleBindings.on('kCBMsgId80', function(args) {
 /**
  * Reade value directly from handle
  *
- * @param  {[type]} deviceUuid [description]
+ * @param  {[type]} peripheralId [description]
  * @param  {[type]} handle     [description]
  *
  * @discussion tested
  */
-nobleBindings.readHandle = function(deviceUuid, handle) {
+nobleBindings.readHandle = function(peripheralId, handle) {
   this.sendCBMsg(77, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgDescriptorHandle: handle
   });
 };
@@ -840,17 +840,17 @@ nobleBindings.readHandle = function(deviceUuid, handle) {
 /**
  * Write value directly to handle
  *
- * @param  {[type]} deviceUuid      [description]
+ * @param  {[type]} peripheralId      [description]
  * @param  {[type]} handle          [description]
  * @param  {[type]} data            [description]
  * @param  {[type]} withoutResponse [description]
  *
  * @discussion tested
  */
-nobleBindings.writeHandle = function(deviceUuid, handle, data, withoutResponse) {
+nobleBindings.writeHandle = function(peripheralId, handle, data, withoutResponse) {
   // TODO: use without response
   this.sendCBMsg(78, {
-    kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
+    kCBMsgArgDeviceUUID: this._peripherals[peripheralId].uuid,
     kCBMsgArgDescriptorHandle: handle,
     kCBMsgArgData: data
   });

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -153,69 +153,69 @@ Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, a
   }
 };
 
-Noble.prototype.connect = function(peripheralUuid) {
-  this._bindings.connect(peripheralUuid);
+Noble.prototype.connect = function(peripheralId) {
+  this._bindings.connect(peripheralId);
 };
 
-Noble.prototype.onConnect = function(peripheralUuid, error) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onConnect = function(peripheralId, error) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.state = error ? 'error' : 'connected';
     peripheral.emit('connect', error);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' connected!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' connected!');
   }
 };
 
-Noble.prototype.disconnect = function(peripheralUuid) {
-  this._bindings.disconnect(peripheralUuid);
+Noble.prototype.disconnect = function(peripheralId) {
+  this._bindings.disconnect(peripheralId);
 };
 
-Noble.prototype.onDisconnect = function(peripheralUuid) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onDisconnect = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.state = 'disconnected';
     peripheral.emit('disconnect');
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' disconnected!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' disconnected!');
   }
 };
 
-Noble.prototype.updateRssi = function(peripheralUuid) {
-  this._bindings.updateRssi(peripheralUuid);
+Noble.prototype.updateRssi = function(peripheralId) {
+  this._bindings.updateRssi(peripheralId);
 };
 
-Noble.prototype.onRssiUpdate = function(peripheralUuid, rssi) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onRssiUpdate = function(peripheralId, rssi) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.rssi = rssi;
 
     peripheral.emit('rssiUpdate', rssi);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' RSSI update!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' RSSI update!');
   }
 };
 
-Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
-  this._bindings.discoverServices(peripheralUuid, uuids);
+Noble.prototype.discoverServices = function(peripheralId, uuids) {
+  this._bindings.discoverServices(peripheralId, uuids);
 };
 
-Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onServicesDiscover = function(peripheralId, serviceUuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     var services = [];
 
     for (var i = 0; i < serviceUuids.length; i++) {
       var serviceUuid = serviceUuids[i];
-      var service = new Service(this, peripheralUuid, serviceUuid);
+      var service = new Service(this, peripheralId, serviceUuid);
 
-      this._services[peripheralUuid][serviceUuid] = service;
-      this._characteristics[peripheralUuid][serviceUuid] = {};
-      this._descriptors[peripheralUuid][serviceUuid] = {};
+      this._services[peripheralId][serviceUuid] = service;
+      this._characteristics[peripheralId][serviceUuid] = {};
+      this._descriptors[peripheralId][serviceUuid] = {};
 
       services.push(service);
     }
@@ -224,32 +224,32 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
 
     peripheral.emit('servicesDiscover', services);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' services discover!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' services discover!');
   }
 };
 
-Noble.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
-  this._bindings.discoverIncludedServices(peripheralUuid, serviceUuid, serviceUuids);
+Noble.prototype.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
+  this._bindings.discoverIncludedServices(peripheralId, serviceUuid, serviceUuids);
 };
 
-Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUuid, includedServiceUuids) {
-  var service = this._services[peripheralUuid][serviceUuid];
+Noble.prototype.onIncludedServicesDiscover = function(peripheralId, serviceUuid, includedServiceUuids) {
+  var service = this._services[peripheralId][serviceUuid];
 
   if (service) {
     service.includedServiceUuids = includedServiceUuids;
 
     service.emit('includedServicesDiscover', includedServiceUuids);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' included services discover!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ' included services discover!');
   }
 };
 
-Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
-  this._bindings.discoverCharacteristics(peripheralUuid, serviceUuid, characteristicUuids);
+Noble.prototype.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
+  this._bindings.discoverCharacteristics(peripheralId, serviceUuid, characteristicUuids);
 };
 
-Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid, characteristics) {
-  var service = this._services[peripheralUuid][serviceUuid];
+Noble.prototype.onCharacteristicsDiscover = function(peripheralId, serviceUuid, characteristics) {
+  var service = this._services[peripheralId][serviceUuid];
 
   if (service) {
     var characteristics_ = [];
@@ -259,14 +259,14 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
 
       var characteristic = new Characteristic(
                                 this,
-                                peripheralUuid,
+                                peripheralId,
                                 serviceUuid,
                                 characteristicUuid,
                                 characteristics[i].properties
                             );
 
-      this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
+      this._characteristics[peripheralId][serviceUuid][characteristicUuid] = characteristic;
+      this._descriptors[peripheralId][serviceUuid][characteristicUuid] = {};
 
       characteristics_.push(characteristic);
     }
@@ -275,74 +275,74 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
 
     service.emit('characteristicsDiscover', characteristics_);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' characteristics discover!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ' characteristics discover!');
   }
 };
 
-Noble.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
-   this._bindings.read(peripheralUuid, serviceUuid, characteristicUuid);
+Noble.prototype.read = function(peripheralId, serviceUuid, characteristicUuid) {
+   this._bindings.read(peripheralId, serviceUuid, characteristicUuid);
 };
 
-Noble.prototype.onRead = function(peripheralUuid, serviceUuid, characteristicUuid, data, isNotification) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onRead = function(peripheralId, serviceUuid, characteristicUuid, data, isNotification) {
+  var characteristic = this._characteristics[peripheralId][serviceUuid][characteristicUuid];
 
   if (characteristic) {
     characteristic.emit('data', data, isNotification);
 
     characteristic.emit('read', data, isNotification); // for backwards compatbility
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' read!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ' read!');
   }
 };
 
-Noble.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-   this._bindings.write(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse);
+Noble.prototype.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
+   this._bindings.write(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse);
 };
 
-Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onWrite = function(peripheralId, serviceUuid, characteristicUuid) {
+  var characteristic = this._characteristics[peripheralId][serviceUuid][characteristicUuid];
 
   if (characteristic) {
     characteristic.emit('write');
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' write!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ' write!');
   }
 };
 
-Noble.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
-   this._bindings.broadcast(peripheralUuid, serviceUuid, characteristicUuid, broadcast);
+Noble.prototype.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
+   this._bindings.broadcast(peripheralId, serviceUuid, characteristicUuid, broadcast);
 };
 
-Noble.prototype.onBroadcast = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onBroadcast = function(peripheralId, serviceUuid, characteristicUuid, state) {
+  var characteristic = this._characteristics[peripheralId][serviceUuid][characteristicUuid];
 
   if (characteristic) {
     characteristic.emit('broadcast', state);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' broadcast!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ' broadcast!');
   }
 };
 
-Noble.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
-   this._bindings.notify(peripheralUuid, serviceUuid, characteristicUuid, notify);
+Noble.prototype.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
+   this._bindings.notify(peripheralId, serviceUuid, characteristicUuid, notify);
 };
 
-Noble.prototype.onNotify = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onNotify = function(peripheralId, serviceUuid, characteristicUuid, state) {
+  var characteristic = this._characteristics[peripheralId][serviceUuid][characteristicUuid];
 
   if (characteristic) {
     characteristic.emit('notify', state);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' notify!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ' notify!');
   }
 };
 
-Noble.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  this._bindings.discoverDescriptors(peripheralUuid, serviceUuid, characteristicUuid);
+Noble.prototype.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
+  this._bindings.discoverDescriptors(peripheralId, serviceUuid, characteristicUuid);
 };
 
-Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, characteristicUuid, descriptors) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onDescriptorsDiscover = function(peripheralId, serviceUuid, characteristicUuid, descriptors) {
+  var characteristic = this._characteristics[peripheralId][serviceUuid][characteristicUuid];
 
   if (characteristic) {
     var descriptors_ = [];
@@ -352,13 +352,13 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
 
       var descriptor = new Descriptor(
                             this,
-                            peripheralUuid,
+                            peripheralId,
                             serviceUuid,
                             characteristicUuid,
                             descriptorUuid
                         );
 
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+      this._descriptors[peripheralId][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
 
       descriptors_.push(descriptor);
     }
@@ -367,73 +367,73 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
 
     characteristic.emit('descriptorsDiscover', descriptors_);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' descriptors discover!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ' descriptors discover!');
   }
 };
 
-Noble.prototype.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  this._bindings.readValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+Noble.prototype.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
+  this._bindings.readValue(peripheralId, serviceUuid, characteristicUuid, descriptorUuid);
 };
 
-Noble.prototype.onValueRead = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+Noble.prototype.onValueRead = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  var descriptor = this._descriptors[peripheralId][serviceUuid][characteristicUuid][descriptorUuid];
 
   if (descriptor) {
     descriptor.emit('valueRead', data);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value read!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value read!');
   }
 };
 
-Noble.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  this._bindings.writeValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+Noble.prototype.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  this._bindings.writeValue(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data);
 };
 
-Noble.prototype.onValueWrite = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+Noble.prototype.onValueWrite = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
+  var descriptor = this._descriptors[peripheralId][serviceUuid][characteristicUuid][descriptorUuid];
 
   if (descriptor) {
     descriptor.emit('valueWrite');
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value write!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value write!');
   }
 };
 
-Noble.prototype.readHandle = function(peripheralUuid, handle) {
-  this._bindings.readHandle(peripheralUuid, handle);
+Noble.prototype.readHandle = function(peripheralId, handle) {
+  this._bindings.readHandle(peripheralId, handle);
 };
 
-Noble.prototype.onHandleRead = function(peripheralUuid, handle, data) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onHandleRead = function(peripheralId, handle, data) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.emit('handleRead' + handle, data);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle read!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' handle read!');
   }
 };
 
-Noble.prototype.writeHandle = function(peripheralUuid, handle, data, withoutResponse) {
-  this._bindings.writeHandle(peripheralUuid, handle, data, withoutResponse);
+Noble.prototype.writeHandle = function(peripheralId, handle, data, withoutResponse) {
+  this._bindings.writeHandle(peripheralId, handle, data, withoutResponse);
 };
 
-Noble.prototype.onHandleWrite = function(peripheralUuid, handle) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onHandleWrite = function(peripheralId, handle) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.emit('handleWrite' + handle);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle write!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' handle write!');
   }
 };
 
-Noble.prototype.onHandleNotify = function(peripheralUuid, handle, data) {
-  var peripheral = this._peripherals[peripheralUuid];
+Noble.prototype.onHandleNotify = function(peripheralId, handle, data) {
+  var peripheral = this._peripherals[peripheralId];
 
   if (peripheral) {
     peripheral.emit('handleNotify', handle, data);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle notify!');
+    this.emit('warning', 'unknown peripheral ' + peripheralId + ' handle notify!');
   }
 };
 

--- a/lib/websocket/bindings.js
+++ b/lib/websocket/bindings.js
@@ -146,8 +146,8 @@ NobleBindings.prototype.stopScanning = function() {
   this.emit('scanStop');
 };
 
-NobleBindings.prototype.connect = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.connect = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'connect',
@@ -155,8 +155,8 @@ NobleBindings.prototype.connect = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.disconnect = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.disconnect = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'disconnect',
@@ -164,8 +164,8 @@ NobleBindings.prototype.disconnect = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.updateRssi = function(deviceUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.updateRssi = function(peripheralId) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'updateRssi',
@@ -173,8 +173,8 @@ NobleBindings.prototype.updateRssi = function(deviceUuid) {
   });
 };
 
-NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverServices = function(peripheralId, uuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'discoverServices',
@@ -183,8 +183,8 @@ NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
   });
 };
 
-NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverIncludedServices = function(peripheralId, serviceUuid, serviceUuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'discoverIncludedServices',
@@ -194,8 +194,8 @@ NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceU
   });
 };
 
-NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverCharacteristics = function(peripheralId, serviceUuid, characteristicUuids) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'discoverCharacteristics',
@@ -205,8 +205,8 @@ NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceUu
   });
 };
 
-NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.read = function(peripheralId, serviceUuid, characteristicUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'read',
@@ -216,8 +216,8 @@ NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicU
   });
 };
 
-NobleBindings.prototype.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.write = function(peripheralId, serviceUuid, characteristicUuid, data, withoutResponse) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'write',
@@ -229,8 +229,8 @@ NobleBindings.prototype.write = function(deviceUuid, serviceUuid, characteristic
   });
 };
 
-NobleBindings.prototype.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.broadcast = function(peripheralId, serviceUuid, characteristicUuid, broadcast) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'broadcast',
@@ -241,8 +241,8 @@ NobleBindings.prototype.broadcast = function(deviceUuid, serviceUuid, characteri
   });
 };
 
-NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.notify = function(peripheralId, serviceUuid, characteristicUuid, notify) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'notify',
@@ -253,8 +253,8 @@ NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristi
   });
 };
 
-NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.discoverDescriptors = function(peripheralId, serviceUuid, characteristicUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'discoverDescriptors',
@@ -264,8 +264,8 @@ NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceUuid, 
   });
 };
 
-NobleBindings.prototype.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.readValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'readValue',
@@ -276,8 +276,8 @@ NobleBindings.prototype.readValue = function(deviceUuid, serviceUuid, characteri
   });
 };
 
-NobleBindings.prototype.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.writeValue = function(peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'writeValue',
@@ -289,8 +289,8 @@ NobleBindings.prototype.writeValue = function(deviceUuid, serviceUuid, character
   });
 };
 
-NobleBindings.prototype.readHandle = function(deviceUuid, handle) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.readHandle = function(peripheralId, handle) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'readHandle',
@@ -299,8 +299,8 @@ NobleBindings.prototype.readHandle = function(deviceUuid, handle) {
   });
 };
 
-NobleBindings.prototype.writeHandle = function(deviceUuid, handle, data, withoutResponse) {
-  var peripheral = this._peripherals[deviceUuid];
+NobleBindings.prototype.writeHandle = function(peripheralId, handle, data, withoutResponse) {
+  var peripheral = this._peripherals[peripheralId];
 
   this._sendCommand({
     action: 'readHandle',

--- a/lib/websocket/bindings.js
+++ b/lib/websocket/bindings.js
@@ -46,7 +46,7 @@ NobleBindings.prototype._onClose = function() {
 
 NobleBindings.prototype._onMessage = function(event) {
   var type = event.type;
-  var peripheralUuid = event.peripheralUuid;
+  var peripheralId = event.peripheralUuid;
   var address = event.address;
   var addressType = event.addressType;
   var connectable = event.connectable;
@@ -76,46 +76,46 @@ NobleBindings.prototype._onMessage = function(event) {
       serviceData: (advertisement.serviceData ? new Buffer(advertisement.serviceData, 'hex') : null)
     };
 
-    this._peripherals[peripheralUuid] = {
-      uuid: peripheralUuid,
+    this._peripherals[peripheralId] = {
+      uuid: peripheralId,
       address: address,
       advertisement: advertisement,
       rssi: rssi
     };
 
-    this.emit('discover', peripheralUuid, address, addressType, connectable, advertisement, rssi);
+    this.emit('discover', peripheralId, address, addressType, connectable, advertisement, rssi);
   } else if (type === 'connect') {
-    this.emit('connect', peripheralUuid);
+    this.emit('connect', peripheralId);
   } else if (type === 'disconnect') {
-    this.emit('disconnect', peripheralUuid);
+    this.emit('disconnect', peripheralId);
   } else if (type === 'rssiUpdate') {
-    this.emit('rssiUpdate', peripheralUuid, rssi);
+    this.emit('rssiUpdate', peripheralId, rssi);
   } else if (type === 'servicesDiscover') {
-    this.emit('servicesDiscover', peripheralUuid, serviceUuids);
+    this.emit('servicesDiscover', peripheralId, serviceUuids);
   } else if (type === 'includedServicesDiscover') {
-    this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+    this.emit('includedServicesDiscover', peripheralId, serviceUuid, includedServiceUuids);
   } else if (type === 'characteristicsDiscover') {
-    this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+    this.emit('characteristicsDiscover', peripheralId, serviceUuid, characteristics);
   } else if (type === 'read') {
-    this.emit('read', peripheralUuid, serviceUuid, characteristicUuid, data, isNotification);
+    this.emit('read', peripheralId, serviceUuid, characteristicUuid, data, isNotification);
   } else if (type === 'write') {
-    this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralId, serviceUuid, characteristicUuid);
   } else if (type === 'broadcast') {
-    this.emit('broadcast', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('broadcast', peripheralId, serviceUuid, characteristicUuid, state);
   } else if (type === 'notify') {
-    this.emit('notify', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('notify', peripheralId, serviceUuid, characteristicUuid, state);
   } else if (type === 'descriptorsDiscover') {
-    this.emit('descriptorsDiscover', peripheralUuid, serviceUuid, characteristicUuid, descriptors);
+    this.emit('descriptorsDiscover', peripheralId, serviceUuid, characteristicUuid, descriptors);
   } else if (type === 'valueRead') {
-    this.emit('valueRead', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+    this.emit('valueRead', peripheralId, serviceUuid, characteristicUuid, descriptorUuid, data);
   } else if (type === 'valueWrite') {
-    this.emit('valueWrite', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+    this.emit('valueWrite', peripheralId, serviceUuid, characteristicUuid, descriptorUuid);
   } else if (type === 'handleRead') {
-    this.emit('handleRead', peripheralUuid, handle, data);
+    this.emit('handleRead', peripheralId, handle, data);
   } else if (type === 'handleWrite') {
-    this.emit('handleWrite', peripheralUuid, handle);
+    this.emit('handleWrite', peripheralId, handle);
   } else if (type === 'handleNotify') {
-    this.emit('handleNotify', peripheralUuid, handle, data);
+    this.emit('handleNotify', peripheralId, handle, data);
   }
 };
 

--- a/ws-slave.js
+++ b/ws-slave.js
@@ -78,7 +78,7 @@ var onMessage = function(message) {
   var command = JSON.parse(message);
 
   var action = command.action;
-  var peripheralUuid = command.peripheralUuid;
+  var peripheralId = command.peripheralUuid;
   var serviceUuids = command.serviceUuids;
   var serviceUuid = command.serviceUuid;
   var characteristicUuids = command.characteristicUuids;
@@ -90,7 +90,7 @@ var onMessage = function(message) {
   var descriptorUuid = command.descriptorUuid;
   var handle = handle;
 
-  var peripheral = peripherals[peripheralUuid];
+  var peripheral = peripherals[peripheralId];
   var service = null;
   var characteristic = null;
   var descriptor = null;


### PR DESCRIPTION
This doesn't include changes to websocket related calls or events since that
would seem to break the public API

There are some internal peripheral.uuid references that should be looked at though.
