### PR TITLE
Update peripheral.js

### DIFF
--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -79,13 +79,28 @@ Peripheral.prototype.discoverServices = function(uuids, callback) {
 
 Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, function(err, services) {
+
+
+    var servicesLength = services.length;
+    var knownUUIDs = [];
+
+    for (var s in services) { 
+      var service = services[s];
+      if(knownUUIDs.indexOf(service.uuid) != -1)
+        servicesLength--;
+      knownUUIDs = knownUUIDs.concat(service.uuid);
+    }
+
     var numDiscovered = 0;
     var allCharacteristics = [];
+
 
     for (var i in services) {
       var service = services[i];
 
       service.discoverCharacteristics(characteristicsUuids, function(error, characteristics) {
+
+
         numDiscovered++;
 
         if (error === null) {
@@ -94,9 +109,9 @@ Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUu
 
             allCharacteristics.push(characteristic);
           }
-        }
+        } 
 
-        if (numDiscovered === services.length) {
+        if (numDiscovered === servicesLength) {
           if (callback) {
             callback(null, services, allCharacteristics);
           }


### PR DESCRIPTION
Fixes a bug, where discovery would never exit if a service UUID is non unique.
