### PR TITLE
Reopen the socket when in bad state

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -67,9 +67,10 @@ var HCI_OE_USER_ENDED_CONNECTION = 0x13;
 var STATUS_MAPPER = require('./hci-status');
 
 var Hci = function() {
-  this._socket = new BluetoothHciSocket();
+  this._socket = null;
   this._isDevUp = null;
   this._state = null;
+  this._pollTimeout = null;
 
   this._handleBuffers = {};
 
@@ -80,7 +81,16 @@ util.inherits(Hci, events.EventEmitter);
 
 Hci.STATUS_MAPPER = STATUS_MAPPER;
 
-Hci.prototype.init = function() {
+Hci.prototype.init = function () {
+  if (this._pollTimeout) {
+    clearTimeout(this._pollTimeout);
+  }
+  if (this._socket) {
+    this._socket.removeAllListeners();
+  }
+  this._isDevUp = null;
+  this._socket = new BluetoothHciSocket();
+
   this._socket.on('data', this.onSocketData.bind(this));
   this._socket.on('error', this.onSocketError.bind(this));
 
@@ -111,7 +121,7 @@ Hci.prototype.pollIsDevUp = function() {
     this._isDevUp = isDevUp;
   }
 
-  setTimeout(this.pollIsDevUp.bind(this), 1000);
+  this._pollTimeout = setTimeout(this.pollIsDevUp.bind(this), 1000);
 };
 
 Hci.prototype.setSocketFilter = function() {
@@ -478,6 +488,8 @@ Hci.prototype.onSocketError = function(error) {
     this.emit('stateChange', 'unauthorized');
   } else if (error.message === 'Network is down') {
     // no-op
+  } else if (error.message === 'File descriptor in bad state') {
+    this.init();
   }
 };
 


### PR DESCRIPTION
On my machine, when the bluetooth driver is restarted, noble does not handle it because the underlying socket is in a bad state. This fix will try to reopen the socket under those circumstances.