### PR TITLE
bump minimum nodejs to >=0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "./index.js",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
As per the failures mentioned in #317, I'm bumping the minimum node version to 0.10