### PR TITLE
Support for pluggable bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ npm install noble
 var noble = require('noble');
 ```
 
+By default, Noble will select bindings to communicate with Bluetooth devices depending on your platform. If you prefer to specify what bindings Noble should use
+
+```javascript
+var noble = require('noble/with-bindings')(require('./my-custom-bindings'));
+```
+
 ### Actions
 
 #### Start scanning

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -9,27 +9,26 @@ var Service = require('./service');
 var Characteristic = require('./characteristic');
 var Descriptor = require('./descriptor');
 
-var bindings = null;
-
-var platform = os.platform();
-
-if (process.env.NOBLE_WEBSOCKET || process.title === 'browser') {
-  bindings = require('./websocket/bindings');
-} else if (process.env.NOBLE_DISTRIBUTED) {
-  bindings = require('./distributed/bindings');
-} else if (platform === 'darwin') {
-  bindings = require('./mac/bindings');
-} else if (platform === 'linux' || platform === 'win32') {
-  bindings = require('./hci-socket/bindings');
-} else {
-  throw new Error('Unsupported platform');
+function guessBindings() {
+  var platform = os.platform();
+  if (process.env.NOBLE_WEBSOCKET || process.title === 'browser') {
+    return require('./websocket/bindings');
+  } else if (process.env.NOBLE_DISTRIBUTED) {
+    return require('./distributed/bindings');
+  } else if (platform === 'darwin') {
+    return require('./mac/bindings');
+  } else if (platform === 'linux' || platform === 'win32') {
+    return require('./hci-socket/bindings');
+  } else {
+    throw new Error('Unsupported platform');
+  }
 }
 
-function Noble() {
+function Noble(bindings) {
   this.state = 'unknown';
   this.address = 'unknown';
 
-  this._bindings = bindings;
+  this._bindings = bindings || guessBindings();
   this._peripherals = {};
   this._services = {};
   this._characteristics = {};

--- a/with-bindings.js
+++ b/with-bindings.js
@@ -1,0 +1,5 @@
+var Noble = require('./lib/noble');
+
+module.exports = function(bindings) {
+  return new Noble(binding);
+};


### PR DESCRIPTION
Some weeks ago I wrote basic Universal Windows Platform bindings for Noble. These bindings are available at https://github.com/hgwood/winble. They are still pretty raw.

While developing those bindings I found out there is no easy way to make Noble use bindings that it is not aware of. Basically you have to edit `noble.js`. I think it would be useful if Noble users (especially bindings developers) could optionally load any bindings they want and make Noble use them without editing its source.

This PR is an attempt to bring this feature to Noble without breaking the API. As of yet it is just a quick sketch of what I'm thinking of and I haven't tested it. Hopefully, from there, we can start a discussion.