### PR TITLE
Don't kill all descriptors when looking for new Characteristics

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -380,7 +380,9 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
   var characteristics = [];
 
   this._characteristics[serviceUuid] = {};
-  this._descriptors[serviceUuid] = {};
+  
+  if (this._descriptors[serviceUuid] == null)
+	this._descriptors[serviceUuid] = {};
 
   var callback = function(data) {
     var opcode = data[0];


### PR DESCRIPTION
Previously when looking for characteristics, all descriptors of the
related service were deleted. This caused a bug when messages on one of
the descriptors arrived before the descriptors were rediscovered. This
should fix it.

Please consider what consequences this change might have, as i don't have in-depth knowledge about noble, **and don't know if this might cause any new bugs**.

Fixed the following Bug for me:

`/root/node/node_modules/noble/lib/hci-socket/gatt.js:608`
`        this._descriptors[serviceUuid][characteristicUuid][descriptors[i].uuid] = descriptors[i];`
`                                                                                ^`

`TypeError: Cannot set property '2902' of undefined`
`    at null.<anonymous> (/root/node/node_modules/noble/lib/hci-socket/gatt.js:608:81)`
`    at Gatt.onAclStreamData (/root/node/node_modules/noble/lib/hci-socket/gatt.js:122:26)`
`    at emitTwo (events.js:92:20)`
`    at emit (events.js:172:7)`
`    at AclStream.push (/root/node/node_modules/noble/lib/hci-socket/acl-stream.js:35:10)`
`    at NobleBindings.onAclDataPkt (/root/node/node_modules/noble/lib/hci-socket/bindings.js:263:15)`
`    at emitThree (events.js:97:13)`
`    at emit (events.js:175:7)`
`    at Hci.onSocketData (/root/node/node_modules/noble/lib/hci-socket/hci.js:447:14)`
 `   at emitOne (events.js:77:13)`