### PR TITLE
Add Noble constructor parameter as an option to select adapter

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -61,7 +61,7 @@ NobleBindings.prototype.updateRssi = function(peripheralUuid) {
   this._hci.readRssi(this._handles[peripheralUuid]);
 };
 
-NobleBindings.prototype.init = function() {
+NobleBindings.prototype.init = function(deviceId) {
   this.onSigIntBinded = this.onSigInt.bind(this);
 
   process.on('SIGINT', this.onSigIntBinded);
@@ -80,7 +80,7 @@ NobleBindings.prototype.init = function() {
   this._hci.on('encryptChange', this.onEncryptChange.bind(this));
   this._hci.on('aclDataPkt', this.onAclDataPkt.bind(this));
 
-  this._hci.init();
+  this._hci.init(deviceId);
 };
 
 NobleBindings.prototype.onSigInt = function() {

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -80,11 +80,17 @@ util.inherits(Hci, events.EventEmitter);
 
 Hci.STATUS_MAPPER = STATUS_MAPPER;
 
-Hci.prototype.init = function() {
+Hci.prototype.init = function(deviceId) {
+  var envDeviceId = process.env.NOBLE_HCI_DEVICE_ID;
+
   this._socket.on('data', this.onSocketData.bind(this));
   this._socket.on('error', this.onSocketError.bind(this));
 
-  var deviceId = process.env.NOBLE_HCI_DEVICE_ID ? parseInt(process.env.NOBLE_HCI_DEVICE_ID, 10) : undefined;
+  if (deviceId) {
+    deviceId = parseInt(deviceId, 10);
+  } else if (envDeviceId) {
+    deviceId = parseInt(envDeviceId, 10);
+  }
 
   this._socket.bindRaw(deviceId);
   this._socket.start();

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -25,7 +25,7 @@ if (process.env.NOBLE_WEBSOCKET || process.title === 'browser') {
   throw new Error('Unsupported platform');
 }
 
-function Noble() {
+function Noble(deviceId) {
   this.state = 'unknown';
   this.address = 'unknown';
 
@@ -64,7 +64,7 @@ function Noble() {
     }
   }.bind(this));
 
-  this._bindings.init();
+  this._bindings.init(deviceId);
 }
 
 util.inherits(Noble, events.EventEmitter);


### PR DESCRIPTION
Add parameter deviceId to Noble constructor as a second option to select the bluetooth adapter.
Constructor parameter has precedence over environment variable.

Implemented for hci-socket only.
