### PR TITLE
multi role - introduce NOBLE_MULTI_ROLE flag for ignoring peripheral role commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,17 @@ Example, specify ```hci1```:
 sudo NOBLE_HCI_DEVICE_ID=1 node <your file>.js
 ```
 
+### Bleno compatibility
+
+By default noble will send an error whenever a peripheral command is received. If you're intention is to use bleno in tandem with noble, the following environment variable can be used to bypass this functionality.
+
+```sh
+sudo NOBLE_MULTI_ROLE=1 node <your file>.js
+```
+
 ### Reporting all HCI events
 
-By default noble waits for both the advertisement data and scan response data for each Bluetooth address. If your device does not use scan response the following enviroment variable can be used to bypass it.
+By default noble waits for both the advertisement data and scan response data for each Bluetooth address. If your device does not use scan response the following environment variable can be used to bypass it.
 
 
 ```sh
@@ -457,4 +465,3 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [![Analytics](https://ga-beacon.appspot.com/UA-56089547-1/sandeepmistry/noble?pixel)](https://github.com/igrigorik/ga-beacon)
-

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -86,9 +86,13 @@ Gatt.prototype.onAclStreamData = function(cid, data) {
   if (this._currentCommand && data.toString('hex') === this._currentCommand.buffer.toString('hex')) {
     debug(this._address + ': echo ... echo ... echo ...');
   } else if (data[0] % 2 === 0) {
-    var requestType = data[0];
-    debug(this._address + ': replying with REQ_NOT_SUPP to 0x' + requestType.toString(16));
-    this.writeAtt(this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP));
+    if (process.env.NOBLE_MULTI_ROLE) {
+      debug(this._address + ': multi-role flag in use, ignoring command meant for peripheral role.');
+    } else {
+      var requestType = data[0];
+      debug(this._address + ': replying with REQ_NOT_SUPP to 0x' + requestType.toString(16));
+      this.writeAtt(this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP));
+    }
   } else if (data[0] === ATT_OP_HANDLE_NOTIFY || data[0] === ATT_OP_HANDLE_IND) {
     var valueHandle = data.readUInt16LE(1);
     var valueData = data.slice(3);


### PR DESCRIPTION
See #377 

Patch 6701fc61c5c0f44b948d90f12013ea464baffc80 introduced default functionality in noble to send error responses for commands meant for peripheral roles. This is problematic for use with bleno, as all commands that bleno is meant to receive will send back REQ_NOT_SUPPORTED. 

The introduction of the NOBLE_MULTI_ROLE flag will prevent this functionality, as well as provide a flag for all future multi role patches to be placed under. 

Bryce