### PR TITLE
Support "long writes" when using hci socket on Linux

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -18,6 +18,10 @@ var ATT_OP_READ_BY_GROUP_REQ        = 0x10;
 var ATT_OP_READ_BY_GROUP_RESP       = 0x11;
 var ATT_OP_WRITE_REQ                = 0x12;
 var ATT_OP_WRITE_RESP               = 0x13;
+var ATT_OP_PREPARE_WRITE_REQ        = 0x16;
+var ATT_OP_PREPARE_WRITE_RESP       = 0x17;
+var ATT_OP_EXECUTE_WRITE_REQ        = 0x18;
+var ATT_OP_EXECUTE_WRITE_RESP       = 0x19;
 var ATT_OP_HANDLE_NOTIFY            = 0x1b;
 var ATT_OP_HANDLE_IND               = 0x1d;
 var ATT_OP_HANDLE_CNF               = 0x1e;
@@ -264,6 +268,10 @@ Gatt.prototype.findInfoRequest = function(startHandle, endHandle) {
 Gatt.prototype.writeRequest = function(handle, data, withoutResponse) {
   var buf = new Buffer(3 + data.length);
 
+  if (withoutResponse && data.length + 3 > this._mtu) {
+    console.warn(this._address + ": writeRequest of " + data.length + " bytes exceeds MTU and will be truncated");
+  }
+
   buf.writeUInt8(withoutResponse ? ATT_OP_WRITE_CMD : ATT_OP_WRITE_REQ , 0);
   buf.writeUInt16LE(handle, 1);
 
@@ -271,6 +279,29 @@ Gatt.prototype.writeRequest = function(handle, data, withoutResponse) {
     buf.writeUInt8(data.readUInt8(i), i + 3);
   }
 
+  return buf;
+};
+
+Gatt.prototype.prepareWriteRequest = function(handle, offset, data) {
+  var buf = new Buffer(5 + data.length);
+
+  if (data.length + 5 > this._mtu) {
+    console.warn(this._address + ": prepareWriteRequest of " + data.length + "exceeds MTU");
+  }
+
+  buf.writeUInt8(ATT_OP_PREPARE_WRITE_REQ);
+  buf.writeUInt16LE(handle, 1);
+  buf.writeUInt16LE(offset, 3);
+  for (var i = 0; i < data.length; i++) {
+    buf.writeUInt8(data.readUInt8(i), i + 5);
+  }
+  return buf;
+};
+
+Gatt.prototype.executeWriteRequest = function(handle, cancelPreparedWrites) {
+  var buf = new Buffer(2);
+  buf.writeUInt8(ATT_OP_EXECUTE_WRITE_REQ);
+  buf.writeUInt8(cancelPreparedWrites ? 0 : 1, 1);
   return buf;
 };
 
@@ -493,7 +524,9 @@ Gatt.prototype.read = function(serviceUuid, characteristicUuid) {
 Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutResponse) {
   var characteristic = this._characteristics[serviceUuid][characteristicUuid];
 
-  if (withoutResponse) {
+  if (data.length + 3 > this._mtu) {
+    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
+  } else if (withoutResponse) {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, true), null, function() {
       this.emit('write', this._address, serviceUuid, characteristicUuid);
     }.bind(this));
@@ -506,6 +539,45 @@ Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutRe
       }
     }.bind(this));
   }
+};
+
+/* Perform a "long write" as described Bluetooth Spec section 4.9.4 "Write Long Characteristic Values" */
+Gatt.prototype.longWrite = function(serviceUuid, characteristicUuid, data, withoutResponse) {
+  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+  var limit = this._mtu - 5;
+
+  var prepareWriteCallback = function(data_chunk) {
+    return function(resp) {
+      var opcode = resp[0];
+      if (opcode != ATT_OP_PREPARE_WRITE_RESP) {
+        console.warn(this._address + ": unexpected reply opcode %d (expecting ATT_OP_PREPARE_WRITE_RESP)", opcode);
+      }
+      else {
+        var expected_length = data_chunk.length + 5;
+        if (resp.length != expected_length) {
+          /* the response should contain the data packet echoed back to the caller */
+          console.warn(this._address + ": unexpected prepareWriteResponse length %d (expecting %d)", resp.length, expected_length);
+        }
+      }
+    }.bind(this);
+  }.bind(this);
+
+  /* split into prepare-write chunks and queue them */
+  var offset = 0;
+  while (offset < data.length) {
+    var end = offset+limit;
+    var chunk = data.slice(offset, end);
+    this._queueCommand(this.prepareWriteRequest(characteristic.valueHandle, offset, chunk), prepareWriteCallback(chunk));
+    offset = end;
+  }
+
+  /* queue the execute command with a callback to emit the write signal when done */
+  this._queueCommand(this.executeWriteRequest(characteristic.valueHandle), function(resp) {
+    var opcode = resp[0];
+    if (opcode == ATT_OP_EXECUTE_WRITE_RESP && !withoutResponse) {
+      emit('write', this._address, serviceUuid, characteristicUuid);
+    }
+  }.bind(this));
 };
 
 Gatt.prototype.broadcast = function(serviceUuid, characteristicUuid, broadcast) {

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -119,6 +119,8 @@ Gatt.prototype.onAclStreamData = function(cid, data) {
       return;
     }
 
+    debug(this._address + ': read: ' + data.toString('hex'));
+
     this._currentCommand.callback(data);
 
     this._currentCommand = null;

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -290,11 +290,8 @@ Gatt.prototype.exchangeMtu = function(mtu) {
       debug(this._address + ': new MTU is ' + newMtu);
 
       this._mtu = newMtu;
-
-      this.emit('mtu', this._address, mtu);
-    } else {
-      this.emit('mtu', this._address, 23);
     }
+    this.emit('mtu', this._address, this._mtu);
   }.bind(this));
 };
 


### PR DESCRIPTION
Working with some OS X based developers, we noticed the OS X backend automatically performs a "Write Long Characteristics Values" (spec section 4.9.4) operation if you write a characteristic value that's longer than the MTU.

Under the HCI backend on Linux, the characteristic value was truncated "on the wire" and an invalid Bluetooth PDU was sent.

This PR adds automatic "Write Long Characeristics" behaviour on Linux, to match the OS X behaviour (I believe this is spec compliant in both cases, section 4.9.4 doesn't put any restrictions on when it is to be used.)

Please let me know if I need to make stylistic/structure changes, I'm new to node.js.  Thanks for a very useful and powerful project!