### PR TITLE
Remove overwrite of an already discovered characteristic

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -240,6 +240,10 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
     for (var i = 0; i < characteristics.length; i++) {
       var characteristicUuid = characteristics[i].uuid;
 
+      if (this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] != null) {
+        continue;
+      }
+
       var characteristic = new Characteristic(
                                 this,
                                 peripheralUuid,


### PR DESCRIPTION
When using libraries based on noble-device, we've found a freezing bug that occurs during connectAndSetup() calls.

The call stack was something like

Device.prototype.connectAndSetup
   NobleDevice.prototype.connectAndSetup
   (create "notify" listener with self.notifyCharacteristic)
       NobleDevice.prototype.discoverServicesAndCharacteristics
           Noble.Peripheral.discoverAllServicesAndCharacteristics
               (some events triggering)
       (overwriting characteristics within
NobleDevice.prototype.discoverServicesAndCharacteristics)
   (now it gets stuck waiting for "notify")

Within NobleDevice.prototype.notifyCharacteristic
(noble-device/lib/noble-device.js) the device is getting a reference
to the characteristic with
this._characteristics[serviceUuid][characteristicUuid](:117) and
waiting for that characteristic's "notify" event to call the callback.

The problem being that if the connection fails, and it goes through a
rediscover/reconnect, inside
NobleDevice.prototype.discoverServicesAndCharacteristics we can see it
overwriting the references for those characteristics
(this._characteristics[serviceUuid][characteristic.uuid] =
characteristic). So now if things run smoothly, within
NobleDevice.prototype.notifyCharacteristic it does another lookup
(:117 again) and now has a brand new reference to a newly created
characteristic. It emits "notify" on that new characteristic. But the
original call to connectAndSetup is still waiting on the old
characteristic object.
