### PR TITLE
Support multiple manufacturer data sections in advertisements

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ peripheral = {
     localName: "<name>",
     txPowerLevel: <int>,
     serviceUuids: ["<service UUID>", ...],
-    manufacturerData: <Buffer>,
+    manufacturerData: <Buffer>, // Can also be an array of buffers if there are multiple sections
     serviceData: [
         {
             uuid: "<service UUID>"

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -94,6 +94,10 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
   var hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
+  var manufacturerDataSaved = previouslyDiscovered ? this._discoveries[address].manufacturerDataSaved : {
+    advertisement: undefined,
+    scanResponse: undefined
+  };
 
   if (type === 0x04) {
     hasScanResponse = true;
@@ -167,7 +171,15 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
         break;
 
       case 0xff: // Manufacturer Specific Data
-        advertisement.manufacturerData = bytes;
+        // Currently, we save one manufacturer specific data field for each
+        // the advertisement and scan response. This allows us to support
+        // manufacturer specific data in each packet, but not multiple
+        // manufacturer data fields in a single packet.
+        if (type == 0x04) {
+          manufacturerDataSaved.scanResponse = bytes;
+        } else {
+          manufacturerDataSaved.advertisement = bytes;
+        }
         break;
     }
 
@@ -178,6 +190,19 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
 
+  // Distill the manufacturer specific data into a version to be presented
+  // to the user
+  if (manufacturerDataSaved.advertisement !== undefined &&
+      manufacturerDataSaved.scanResponse !== undefined) {
+    advertisement.manufacturerData = [manufacturerDataSaved.advertisement, manufacturerDataSaved.scanResponse];
+  } else {
+    if (manufacturerDataSaved.advertisement !== undefined) {
+      advertisement.manufacturerData = manufacturerDataSaved.advertisement;
+    } else if (manufacturerDataSaved.scanResponse !== undefined) {
+      advertisement.manufacturerData = manufacturerDataSaved.scanResponse;
+    }
+  }
+
   this._discoveries[address] = {
     address: address,
     addressType: addressType,
@@ -185,7 +210,8 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     advertisement: advertisement,
     rssi: rssi,
     count: discoveryCount,
-    hasScanResponse: hasScanResponse
+    hasScanResponse: hasScanResponse,
+    manufacturerDataSaved: manufacturerDataSaved
   };
 
   // only report after a scan response event or more than one discovery without a scan response, so more data can be collected


### PR DESCRIPTION
Add support for a manufacturer specific data section in each of the advertisement and the scan response packet. If there are both, they will be returned as an array to the user.

Both fields (if they exist) will also be stored and returned if a future advertisement doesn't have any manufacturer specific fields.
### Notes
1. This is backwards compatible. If there is only one manufacturer section in only some packets it will be preserved and presented with each incoming advertisement.
2. This only supports one manufacturer section in the advertisement and scan response. It is not general for any number of manufacturer sections. The reason is it is difficult to maintain backwards compatibility if someone is using the stored manufacturer data feature.
3. If it is ok to break backwards compatibility, it would be easy to support any number of manufacturer sections by erasing them on each advertisement (like the service uuids and data).
