### PR TITLE
Add raw eir and scanResponse to advertisement object

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -97,10 +97,12 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   if (type === 0x04) {
     hasScanResponse = true;
+    advertisement.scanResponse=eir;
   } else {
     // reset service data every non-scan response event
     advertisement.serviceData = [];
     advertisement.serviceUuids = [];
+    advertisement.eir=eir;
   }
 
   discoveryCount++;


### PR DESCRIPTION
Hi,
for my project I need access to raw advertisement's eir and scan response hex data. So I added them to advertisement object in gap.js.