### PR TITLE
Added extraction of the solicitation service UUID fields

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -89,7 +89,8 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     txPowerLevel: undefined,
     manufacturerData: undefined,
     serviceData: [],
-    serviceUuids: []
+    serviceUuids: [],
+    solicitationServiceUuids: []
   };
 
   var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
@@ -101,6 +102,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     // reset service data every non-scan response event
     advertisement.serviceData = [];
     advertisement.serviceUuids = [];
+    advertisement.solicitationServiceUuids = [];
   }
 
   discoveryCount++;
@@ -155,7 +157,25 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
       case 0x0a: // Tx Power Level
         advertisement.txPowerLevel = bytes.readInt8(0);
         break;
+        
+      case  0x14: // List of 16 bit solicitation UUIDs
+        for (j = 0; j < bytes.length; j += 2) {
+          solicitationServiceUuid = bytes.readUInt16LE(j).toString(16);
+          if (advertisement.solicitationServiceUuids.indexOf(solicitationServiceUuid) === -1) {
+            advertisement.solicitationServiceUuids.push(solicitationServiceUuid);
+          }
+        }
+        break;
 
+      case  0x15: // List of 128 bit solicitation UUIDs
+        for (j = 0; j < bytes.length; j += 16) {
+          solicitationServiceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+          if (advertisement.solicitationServiceUuids.indexOf(solicitationServiceUuid) === -1) {
+            advertisement.solicitationServiceUuids.push(solicitationServiceUuid);
+          }
+        }
+        break;
+        
       case 0x16: // Service Data, there can be multiple occurences
         var serviceDataUuid = bytes.slice(0, 2).toString('hex').match(/.{1,2}/g).reverse().join('');
         var serviceData = bytes.slice(2, bytes.length);
@@ -164,6 +184,15 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
           uuid: serviceDataUuid,
           data: serviceData
         });
+        break;
+
+      case  0x1F: // List of 32 bit solicitation UUIDs
+        for (j = 0; j < bytes.length; j += 4) {
+          solicitationServiceUuid = bytes.readUInt32LE(j).toString(16);
+          if (advertisement.solicitationServiceUuids.indexOf(solicitationServiceUuid) === -1) {
+            advertisement.solicitationServiceUuids.push(solicitationServiceUuid);
+          }
+        }
         break;
 
       case 0xff: // Manufacturer Specific Data


### PR DESCRIPTION
As discussed, modified gap.js to extract the three types of solicitation service UUID fields.