### PR TITLE
Support for long write (writeHandle; write without response)

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -525,12 +525,12 @@ Gatt.prototype.read = function(serviceUuid, characteristicUuid) {
 Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutResponse) {
   var characteristic = this._characteristics[serviceUuid][characteristicUuid];
 
-  if (withoutResponse) {
+  if (data.length + 3 > this._mtu) {
+    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
+  } else if (withoutResponse) {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, true), null, function() {
       this.emit('write', this._address, serviceUuid, characteristicUuid);
     }.bind(this));
-  } else if (data.length + 3 > this._mtu) {
-    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
   } else {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, false), function(data) {
       var opcode = data[0];
@@ -583,6 +583,48 @@ Gatt.prototype.longWrite = function(serviceUuid, characteristicUuid, data, witho
     }
   }.bind(this));
 };
+
+/* "long write" for handle */
+Gatt.prototype.longWriteHandle = function(handle, data, withoutResponse) {
+  var limit = this._mtu - 5;
+
+  var prepareWriteCallback = function(data_chunk) {
+    return function(resp) {
+      var opcode = resp[0];
+
+      if (opcode != ATT_OP_PREPARE_WRITE_RESP) {
+        debug(this._address + ': unexpected reply opcode %d (expecting ATT_OP_PREPARE_WRITE_RESP)', opcode);
+      } else {
+        var expected_length = data_chunk.length + 5;
+
+        if (resp.length !== expected_length) {
+          /* the response should contain the data packet echoed back to the caller */
+          debug(this._address + ': unexpected prepareWriteResponse length %d (expecting %d)', resp.length, expected_length);
+        }
+      }
+    }.bind(this);
+  }.bind(this);
+
+  /* split into prepare-write chunks and queue them */
+  var offset = 0;
+
+  while (offset < data.length) {
+    var end = offset+limit;
+    var chunk = data.slice(offset, end);
+    this._queueCommand(this.prepareWriteRequest(handle, offset, chunk), prepareWriteCallback(chunk));
+    offset = end;
+  }
+
+  /* queue the execute command with a callback to emit the write signal when done */
+  this._queueCommand(this.executeWriteRequest(handle), function(resp) {
+    var opcode = resp[0];
+
+    if (opcode === ATT_OP_EXECUTE_WRITE_RESP && !withoutResponse) {
+      this.emit('handleWrite', this._address, handle);
+    }
+  }.bind(this));
+};
+
 
 Gatt.prototype.broadcast = function(serviceUuid, characteristicUuid, broadcast) {
   var characteristic = this._characteristics[serviceUuid][characteristicUuid];
@@ -728,7 +770,9 @@ Gatt.prototype.readHandle = function(handle) {
 };
 
 Gatt.prototype.writeHandle = function(handle, data, withoutResponse) {
-  if (withoutResponse) {
+  if (data.length + 3 > this._mtu) {
+    return this.longWriteHandle(handle, data, withoutResponse);
+  } else if (withoutResponse) {
     this._queueCommand(this.writeRequest(handle, data, true), null, function() {
       this.emit('handleWrite', this._address, handle);
     }.bind(this));


### PR DESCRIPTION
Hi,
for my project I use writeHandle. I noticed it does not support long writes. So I have added the longWriteHandle (basically copied longWrite with minor changes) in gatt.js, and modified the writeHandle. 

BTW. I think long write should also be possible with standard writes without response. So I have also modified the gatt write to support this.
