### PR TITLE
Issue https://github.com/sandeepmistry/noble/issues/471

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -23,7 +23,12 @@ util.inherits(Gap, events.EventEmitter);
 Gap.prototype.startScanning = function(allowDuplicates) {
   this._scanState = 'starting';
   this._scanFilterDuplicates = !allowDuplicates;
-
+  
+  // Always set scan parameters before scanning 
+  // https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=229737
+  // p106 - p107
+  this._hci.setScanEnabled(false, true);
+  this._hci.setScanParameters();
   this._hci.setScanEnabled(true, this._scanFilterDuplicates);
 };
 


### PR DESCRIPTION
Always set scan parameters before an active scanning.

Now scan parameters are only set when an hci device becomes ready : 
refer Hci.prototype.pollIsDevUp and this code that is called when device becomes up :

 in hci.js l550 :
```
    if (hciVer < 0x06) {
      this.emit('stateChange', 'unsupported');
    } else if (this._state !== 'poweredOn') {
      this.setScanEnabled(false, true);
      this.setScanParameters();
    }
```
I would remove :

      this.setScanEnabled(false, true);
      this.setScanParameters();

and only set scan parameters when a scan is needed. 
But in code scan parameters response is used in device up processus, when it is received a :

    this.emit('stateChange', 'poweredOn');

is sent.I would suggest emitting this event when all responses command sent in  pollIsDevUp have been received. But we can also sending this event in :

 in hci.js l550 :
```
    if (hciVer < 0x06) {
      this.emit('stateChange', 'unsupported');
    } else if (this._state !== 'poweredOn') {
      //this.setScanEnabled(false, true);
      //this.setScanParameters();
      this.emit('stateChange', 'poweredOn');
    }
```