### PR TITLE
[hci-socket] Add L2CAP signaling layer

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -7,6 +7,7 @@ var AclStream = require('./acl-stream');
 var Gatt = require('./gatt');
 var Gap = require('./gap');
 var Hci = require('./hci');
+var Signaling = require('./signaling');
 
 
 var NobleBindings = function() {
@@ -22,6 +23,7 @@ var NobleBindings = function() {
   this._handles = {};
   this._gatts = {};
   this._aclStreams = {};
+  this._signalings = {};
 
   this._hci = new Hci();
   this._gap = new Gap(this._hci);
@@ -180,8 +182,10 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
 
     var aclStream = new AclStream(this._hci, handle, this._hci.addressType, this._hci.address, addressType, address);
     var gatt = new Gatt(address, aclStream);
+    var signaling = new Signaling(handle, aclStream);
 
     this._gatts[uuid] = this._gatts[handle] = gatt;
+    this._signalings[uuid] = this._signalings[handle] = signaling;
     this._aclStreams[handle] = aclStream;
     this._handles[uuid] = handle;
     this._handles[handle] = uuid;
@@ -201,6 +205,8 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
     this._gatts[handle].on('handleRead', this.onHandleRead.bind(this));
     this._gatts[handle].on('handleWrite', this.onHandleWrite.bind(this));
     this._gatts[handle].on('handleNotify', this.onHandleNotify.bind(this));
+
+    this._signalings[handle].on('connectionParameterUpdateRequest', this.onConnectionParameterUpdateRequest.bind(this));
 
     this._gatts[handle].exchangeMtu(256);
   } else {
@@ -235,9 +241,12 @@ NobleBindings.prototype.onDisconnComplete = function(handle, reason) {
   if (uuid) {
     this._aclStreams[handle].push(null, null);
     this._gatts[handle].removeAllListeners();
+    this._signalings[handle].removeAllListeners();
 
     delete this._gatts[uuid];
     delete this._gatts[handle];
+    delete this._signalings[uuid];
+    delete this._signalings[handle];
     delete this._aclStreams[handle];
     delete this._handles[uuid];
     delete this._handles[handle];
@@ -488,6 +497,10 @@ NobleBindings.prototype.onHandleNotify = function(address, handle, data) {
   var uuid = address.split(':').join('').toLowerCase();
 
   this.emit('handleNotify', uuid, handle, data);
+};
+
+NobleBindings.prototype.onConnectionParameterUpdateRequest = function(handle, minInterval, maxInterval, latency, supervisionTimeout) {
+  this._hci.connUpdateLe(handle, minInterval, maxInterval, latency, supervisionTimeout);
 };
 
 module.exports = new NobleBindings();

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -45,6 +45,7 @@ var OCF_LE_SET_EVENT_MASK = 0x0001;
 var OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
 var OCF_LE_SET_SCAN_ENABLE = 0x000c;
 var OCF_LE_CREATE_CONN = 0x000d;
+var OCF_LE_CONN_UPDATE = 0x0013;
 var OCF_LE_START_ENCRYPTION = 0x0019;
 
 var DISCONNECT_CMD = OCF_DISCONNECT | OGF_LINK_CTL << 10;
@@ -63,6 +64,7 @@ var LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
 var LE_SET_SCAN_PARAMETERS_CMD = OCF_LE_SET_SCAN_PARAMETERS | OGF_LE_CTL << 10;
 var LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | OGF_LE_CTL << 10;
 var LE_CREATE_CONN_CMD = OCF_LE_CREATE_CONN | OGF_LE_CTL << 10;
+var LE_CONN_UPDATE_CMD = OCF_LE_CONN_UPDATE | OGF_LE_CTL << 10;
 var LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | OGF_LE_CTL << 10;
 
 var HCI_OE_USER_ENDED_CONNECTION = 0x13;
@@ -320,6 +322,28 @@ Hci.prototype.createLeConn = function(address, addressType) {
   this._socket.write(cmd);
 };
 
+Hci.prototype.connUpdateLe = function(handle, minInterval, maxInterval, latency, supervisionTimeout) {
+  var cmd = new Buffer(18);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_CONN_UPDATE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0e, 3);
+
+  // data
+  cmd.writeUInt16LE(handle, 4);
+  cmd.writeUInt16LE(Math.floor(minInterval / 1.25), 6); // min interval
+  cmd.writeUInt16LE(Math.floor(maxInterval / 1.25), 8); // max interval
+  cmd.writeUInt16LE(latency, 10); // latency
+  cmd.writeUInt16LE(Math.floor(supervisionTimeout / 10), 12); // supervision timeout
+  cmd.writeUInt16LE(0x0000, 14); // min ce length
+  cmd.writeUInt16LE(0x0000, 16); // max ce length
+
+  debug('conn update le - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
 
 Hci.prototype.startLeEncryption = function(handle, random, diversifier, key) {
   var cmd = new Buffer(32);

--- a/lib/hci-socket/signaling.js
+++ b/lib/hci-socket/signaling.js
@@ -1,0 +1,76 @@
+var debug = require('debug')('signaling');
+
+var events = require('events');
+var os = require('os');
+var util = require('util');
+
+var CONNECTION_PARAMETER_UPDATE_REQUEST  = 0x12;
+var CONNECTION_PARAMETER_UPDATE_RESPONSE = 0x13;
+
+var SIGNALING_CID = 0x0005;
+
+var Signaling = function(handle, aclStream) {
+  this._handle = handle;
+  this._aclStream = aclStream;
+
+  this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
+  this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
+
+  this._aclStream.on('data', this.onAclStreamDataBinded);
+  this._aclStream.on('end', this.onAclStreamEndBinded);
+};
+
+util.inherits(Signaling, events.EventEmitter);
+
+Signaling.prototype.onAclStreamData = function(cid, data) {
+  if (cid !== SIGNALING_CID) {
+    return;
+  }
+
+  debug('onAclStreamData: ' + data.toString('hex'));
+
+  var code = data.readUInt8(0);
+  var identifier = data.readUInt8(1);
+  var length = data.readUInt16LE(2);
+  var signalingData = data.slice(4);
+
+  debug('\tcode = ' + code);
+  debug('\tidentifier = ' + identifier);
+  debug('\tlength = ' + length);
+
+  if (code === CONNECTION_PARAMETER_UPDATE_REQUEST) {
+    this.processConnectionParameterUpdateRequest(identifier, signalingData);
+  }
+};
+
+Signaling.prototype.onAclStreamEnd = function() {
+  this._aclStream.removeListener('data', this.onAclStreamDataBinded);
+  this._aclStream.removeListener('end', this.onAclStreamEndBinded);
+};
+
+Signaling.prototype.processConnectionParameterUpdateRequest = function(identifier, data) {
+  var minInterval = data.readUInt16LE(0) * 1.25;
+  var maxInterval = data.readUInt16LE(2) * 1.25;
+  var latency = data.readUInt16LE(4);
+  var supervisionTimeout = data.readUInt16LE(6) * 10;
+
+  debug('\t\tmin interval = ', minInterval);
+  debug('\t\tmax interval = ', maxInterval);
+  debug('\t\tlatency = ', latency);
+  debug('\t\tsupervision timeout = ', supervisionTimeout);
+
+  if (os.platform() !== 'linux' || process.env.HCI_CHANNEL_USER) {
+    var response = new Buffer(6);
+
+    response.writeUInt8(CONNECTION_PARAMETER_UPDATE_RESPONSE, 0); // code
+    response.writeUInt8(identifier, 1); // identifier
+    response.writeUInt16LE(2, 2); // length
+    response.writeUInt16LE(0, 4);
+
+    this._aclStream.write(SIGNALING_CID, response);
+
+    this.emit('connectionParameterUpdateRequest', this._handle, minInterval, maxInterval, latency, supervisionTimeout);
+  }
+};
+
+module.exports = Signaling;


### PR DESCRIPTION
Enabled for non-Linux or Linux user channel mode.

Fixes #468.

Can be tested via `npm install sandeepmistry/noble#l2cap-signaling`