### PR TITLE
[hci-socket] Workarounds for scanning with N.T.C. C.H.I.P

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -1,7 +1,10 @@
 var debug = require('debug')('gap');
 
 var events = require('events');
+var os = require('os');
 var util = require('util');
+
+var isChip = (os.platform() === 'linux') && (os.release().indexOf('-ntc') !== -1);
 
 var Gap = function(hci) {
   this._hci = hci;
@@ -23,12 +26,18 @@ util.inherits(Gap, events.EventEmitter);
 Gap.prototype.startScanning = function(allowDuplicates) {
   this._scanState = 'starting';
   this._scanFilterDuplicates = !allowDuplicates;
-  
-  // Always set scan parameters before scanning 
+
+  // Always set scan parameters before scanning
   // https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=229737
   // p106 - p107
   this._hci.setScanEnabled(false, true);
   this._hci.setScanParameters();
+
+  if (isChip) {
+    // work around for Next Thing Co. C.H.I.P, always allow duplicates, to get scan response
+    this._scanFilterDuplicates = false;
+  }
+
   this._hci.setScanEnabled(true, this._scanFilterDuplicates);
 };
 
@@ -80,8 +89,7 @@ Gap.prototype.onLeScanEnableSetCmd = function(enable, filterDuplicates) {
 
       this.emit('scanStart', this._scanFilterDuplicates);
     }
-  } else if ((this._scanState == 'stopping' || this._scanState == 'stopped') &&
-             (enable)) {
+  } else if ((this._scanState == 'stopping' || this._scanState == 'stopped') && enable) {
     // Someone started scanning on us.
     this.emit('scanStart', this._scanFilterDuplicates);
   }

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -633,20 +633,25 @@ Hci.prototype.processLeConnComplete = function(status, data) {
   this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
 };
 
-Hci.prototype.processLeAdvertisingReport = function(status, data) {
-  var type = data.readUInt8(0); // ignore for now
-  var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-  var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
-  var eir = data.slice(9, data.length - 1);
-  var rssi = data.readInt8(data.length - 1);
+Hci.prototype.processLeAdvertisingReport = function(count, data) {
+  for (var i = 0; i < count; i++) {
+    var type = data.readUInt8(0);
+    var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
+    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+    var eirLength = data.readUInt8(8);
+    var eir = data.slice(9, eirLength + 9);
+    var rssi = data.readInt8(eirLength + 9);
 
-  debug('\t\t\ttype = ' + type);
-  debug('\t\t\taddress = ' + address);
-  debug('\t\t\taddress type = ' + addressType);
-  debug('\t\t\teir = ' + eir.toString('hex'));
-  debug('\t\t\trssi = ' + rssi);
+    debug('\t\t\ttype = ' + type);
+    debug('\t\t\taddress = ' + address);
+    debug('\t\t\taddress type = ' + addressType);
+    debug('\t\t\teir = ' + eir.toString('hex'));
+    debug('\t\t\trssi = ' + rssi);
 
-  this.emit('leAdvertisingReport', status, type, address, addressType, eir, rssi);
+    this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
+
+    data = data.slice(eirLength + 10);
+  }
 };
 
 Hci.prototype.processLeConnUpdateComplete = function(status, data) {


### PR DESCRIPTION
* Allows disable filtering of duplicates on NTC CHIP (filter at higher level)
* Support multiple reports per LE meta event advertising report

Fixes #469.

Can be tested via `npm install sandeepmistry/noble#ntc-chip-scan-workarounds`