### PR TITLE
handle write resp error for write_request

### DIFF
--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -56,8 +56,8 @@ Characteristic.prototype.write = function(data, withoutResponse, callback) {
   }
 
   if (callback) {
-    this.once('write', function() {
-      callback(null);
+    this.once('write', function(err) {
+      callback(err);
     });
   }
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -362,10 +362,10 @@ NobleBindings.prototype.write = function(peripheralUuid, serviceUuid, characteri
   }
 };
 
-NobleBindings.prototype.onWrite = function(address, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.onWrite = function(address, serviceUuid, characteristicUuid, err) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('write', uuid, serviceUuid, characteristicUuid);
+  this.emit('write', uuid, serviceUuid, characteristicUuid, err);
 };
 
 NobleBindings.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -536,7 +536,10 @@ Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutRe
       var opcode = data[0];
 
       if (opcode === ATT_OP_WRITE_RESP) {
-        this.emit('write', this._address, serviceUuid, characteristicUuid);
+        this.emit('write', this._address, serviceUuid, characteristicUuid, null);
+      }
+      else if(opcode === ATT_OP_ERROR){
+        this.emit('write', this._address, serviceUuid, characteristicUuid, "ATT_OP_ERROR - error code : " + resp[4]);
       }
     }.bind(this));
   }
@@ -577,9 +580,13 @@ Gatt.prototype.longWrite = function(serviceUuid, characteristicUuid, data, witho
   /* queue the execute command with a callback to emit the write signal when done */
   this._queueCommand(this.executeWriteRequest(characteristic.valueHandle), function(resp) {
     var opcode = resp[0];
-
-    if (opcode === ATT_OP_EXECUTE_WRITE_RESP && !withoutResponse) {
-      this.emit('write', this._address, serviceUuid, characteristicUuid);
+    if(!withoutResponse){
+      if (opcode === ATT_OP_EXECUTE_WRITE_RESP) {
+        this.emit('write', this._address, serviceUuid, characteristicUuid, null);
+      }
+      else if(opcode === ATT_OP_ERROR){
+        this.emit('write', this._address, serviceUuid, characteristicUuid, "ATT_OP_ERROR - error code : " + resp[4]);
+      }
     }
   }.bind(this));
 };

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -282,11 +282,11 @@ Noble.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid
    this._bindings.write(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse);
 };
 
-Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid) {
+Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid, err) {
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
-    characteristic.emit('write');
+    characteristic.emit('write', err);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' write!');
   }


### PR DESCRIPTION
Now, error in Write Request are not handled. Write characteristic callback won't be called because there is no else in these conditions in gatt.js :

    if (opcode === ATT_OP_EXECUTE_WRITE_RESP && !withoutResponse) 
and :

    if (opcode === ATT_OP_WRITE_RESP) 
