### PR TITLE
Register onAclStreamDataBinded after sendPairingRequest is called

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -150,7 +150,7 @@ Gatt.prototype.onAclStreamData = function(cid, data) {
 };
 
 Gatt.prototype.onAclStreamEncrypt = function(encrypt) {
-  if (encrypt) {
+  if (encrypt && this._currentCommand) {
     this._security = 'medium';
 
     this.writeAtt(this._currentCommand.buffer);

--- a/lib/hci-socket/smp.js
+++ b/lib/hci-socket/smp.js
@@ -26,22 +26,25 @@ var Smp = function(aclStream, localAddressType, localAddress, remoteAddressType,
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
   this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
 
-  this._aclStream.on('data', this.onAclStreamDataBinded);
   this._aclStream.on('end', this.onAclStreamEndBinded);
 };
 
 util.inherits(Smp, events.EventEmitter);
 
 Smp.prototype.sendPairingRequest = function() {
-  this._preq = new Buffer([
-    SMP_PAIRING_REQUEST,
-    0x03, // IO capability: NoInputNoOutput
-    0x00, // OOB data: Authentication data not present
-    0x01, // Authentication requirement: Bonding - No MITM
-    0x10, // Max encryption key size
-    0x00, // Initiator key distribution: <none>
-    0x01  // Responder key distribution: EncKey
-  ]);
+  if (!this._preq) {
+    this._preq = new Buffer([
+      SMP_PAIRING_REQUEST,
+      0x03, // IO capability: NoInputNoOutput
+      0x00, // OOB data: Authentication data not present
+      0x01, // Authentication requirement: Bonding - No MITM
+      0x10, // Max encryption key size
+      0x00, // Initiator key distribution: <none>
+      0x01  // Responder key distribution: EncKey
+    ]);
+
+    this._aclStream.on('data', this.onAclStreamDataBinded);
+  }
 
   this.write(this._preq);
 };


### PR DESCRIPTION
Changed hci-socket smp to only register onAclStreamDataBinded after sendPairingRequest is called. This fixes a crash where the 'data' event called onAclStreamDataBinded before sendPairingRequest was called as mentioned in issue #295