### PR TITLE
Fix #502 - crash on exit if no BLE adaptor found on Windows

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -66,9 +66,6 @@ NobleBindings.prototype.updateRssi = function(peripheralUuid) {
 NobleBindings.prototype.init = function() {
   this.onSigIntBinded = this.onSigInt.bind(this);
 
-  process.on('SIGINT', this.onSigIntBinded);
-  process.on('exit', this.onExit.bind(this));
-
   this._gap.on('scanStart', this.onScanStart.bind(this));
   this._gap.on('scanStop', this.onScanStop.bind(this));
   this._gap.on('discover', this.onDiscover.bind(this));
@@ -83,6 +80,12 @@ NobleBindings.prototype.init = function() {
   this._hci.on('aclDataPkt', this.onAclDataPkt.bind(this));
 
   this._hci.init();
+
+  /* Add exit handlers after `init()` has completed. If no adaptor
+  is present it can throw an exception - in which case we don't
+  want to try and clear up afterwards (issue #502) */
+  process.on('SIGINT', this.onSigIntBinded);
+  process.on('exit', this.onExit.bind(this));
 };
 
 NobleBindings.prototype.onSigInt = function() {


### PR DESCRIPTION
if `init()` fails we don't want to try and clear up on exit because _usbDevice will be undefined.