### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Node.js BLE (Bluetooth Low Energy) central module.
 
 Want to implement a peripheral? Checkout [bleno](https://github.com/sandeepmistry/bleno)
 
-__Note:__ Mac OS X, Linux and Windows are currently the only supported OSes. Other platforms may be developed later on.
+__Note:__ macOS / Mac OS X, Linux, FreeBSD and Windows are currently the only supported OSes. Other platforms may be developed later on.
 
 ## Prerequisites
 
@@ -41,6 +41,24 @@ sudo yum install bluez bluez-libs bluez-libs-devel
 #### Intel Edison
 
 See [Configure Intel Edison for Bluetooth LE (Smart) Development](http://rexstjohn.com/configure-intel-edison-for-bluetooth-le-smart-development/)
+
+### FreeBSD
+
+Make sure you have GNU Make:
+
+```sh
+sudo pkg install gmake
+```
+
+Disable automatic loading of the default Bluetooth stack by putting [no-ubt.conf](https://gist.github.com/myfreeweb/44f4f3e791a057bc4f3619a166a03b87) into ```/usr/local/etc/devd/no-ubt.conf``` and restarting devd (```sudo service devd restart```).
+
+Unload ```ng_ubt``` kernel module if already loaded:
+
+```sh
+sudo kldunload ng_ubt
+```
+
+Make sure you have read and write permissions on the ```/dev/usb/*``` device that corresponds to your Bluetooth adapter.
 
 ### Windows
 

--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -9,7 +9,7 @@ module.exports = function() {
     return require('./distributed/bindings');
   } else if (platform === 'darwin') {
     return require('./mac/bindings');
-  } else if (platform === 'linux' || platform === 'win32') {
+  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32') {
     return require('./hci-socket/bindings');
   } else {
     throw new Error('Unsupported platform');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "os": [
     "darwin",
     "linux",
+    "freebsd",
     "win32"
   ],
   "dependencies": {


### PR DESCRIPTION
Depends on sandeepmistry/node-bluetooth-hci-socket#48.

The discovery example works! (Tested on: FreeBSD/arm 11.0-STABLE + CSR8510 A10.)