### PR TITLE
Fix startScanning callback calling

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -77,7 +77,9 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
     }
   } else {
     if (callback) {
-      this.once('scanStart', callback);
+      this.once('scanStart', function(filterDuplicates) {
+        callback(null, filterDuplicates);
+      });
     }
 
     this._discoveredPeripheralUUids = [];


### PR DESCRIPTION
According to README, when startScanning is passed a callback as a third argument, that callback is a usual Node-style "error first" callback.
But in fact, when scanning is started successfully, callback is called with `filterDuplicates` value as its first argument.
Here is an example situation where it causes problem:
```
// don't allow duplicates (as by default) but pass a callback
noble.startScanning([], false, function(error) {
  if(error) {
    console.log('Failed to start scanning:', error);
  }
});
```
What happens when you run this code:
`Failed to start scanning: true`

This PR is intended to fix this.