### PR TITLE
Do report errors in characteristics discovery

### DIFF
--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -79,13 +79,33 @@ Peripheral.prototype.discoverServices = function(uuids, callback) {
 
 Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, function(err, services) {
+    if(err) {
+      if(callback) {
+        callback(err);
+      }
+      return;
+    }
+    
     var numDiscovered = 0;
     var allCharacteristics = [];
+    var failed = false;
 
     for (var i in services) {
       var service = services[i];
 
       service.discoverCharacteristics(characteristicsUuids, function(error, characteristics) {
+        if(failed) {
+          // some other characteristic failed and we passed error to the caller, so do nothing anymore
+          return;
+        }
+        if(error) {
+          failed = true;
+          if(callback) {
+            callback(error);
+          }
+          return;
+        }
+        
         numDiscovered++;
 
         if (error === null) {


### PR DESCRIPTION
Before this change, `peripheral.discoverSomeServicesAndCharacteristics`
silently ignored any discovery errors, as a result any error led to callback not being called.