### PR TITLE
Fix destructive query behavior for services, characteristics and desc

### DIFF
--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -317,7 +317,9 @@ nobleBindings.on('kCBMsgId56', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  if (typeof this._peripherals[deviceUuid].services == 'undefined') {
+    this._peripherals[deviceUuid].services = {};
+  }
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -327,7 +329,9 @@ nobleBindings.on('kCBMsgId56', function(args) {
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      if (typeof this._peripherals[deviceUuid].services[service.uuid] == 'undefined') {
+        this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      }
 
       serviceUuids.push(service.uuid);
     }
@@ -435,7 +439,9 @@ nobleBindings.on('kCBMsgId64', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  if (typeof this._peripherals[deviceUuid].services[serviceStartHandle].characteristics == 'undefined') {
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  }
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
@@ -479,9 +485,11 @@ nobleBindings.on('kCBMsgId64', function(args) {
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
+    if (typeof this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] == 'undefined') {
+      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
       this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
       this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
+    }
 
     characteristics.push({
       uuid: characteristic.uuid,

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -47,8 +47,6 @@ nobleBindings.sendCBMsg = function(id, args) {
 };
 
 
-
-
 /**
  * Init xpc connection to blued
  *

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -210,7 +210,7 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
         peripheral.services = [];
 
     // add new items to the peripherals array
-    services.map(function(s) { peripheral.services.push(s) });
+    services.map(function(s) { peripheral.services.push(s); });
 
     // always return a copy of the peripheral services.
     var returnedServices = [];
@@ -271,7 +271,7 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
         service.characteristics = [];
     }
 
-    characteristics_.map(function(c) { service.characteristics.push(c) });
+    characteristics_.map(function(c) { service.characteristics.push(c); });
 
     // return the current list of characteristics.
     var returnedCharacteristics = [];
@@ -375,7 +375,7 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
         characteristic.descriptors = [];
     }
 
-    descriptors_.map(function(c) { characteristic.descriptors.push(c) });
+    descriptors_.map(function(c) { characteristic.descriptors.push(c); });
 
     // return the current list of characteristics.
     var returnedDescriptors = [];

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -194,18 +194,29 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
 
     for (var i = 0; i < serviceUuids.length; i++) {
       var serviceUuid = serviceUuids[i];
-      var service = new Service(this, peripheralUuid, serviceUuid);
 
-      this._services[peripheralUuid][serviceUuid] = service;
-      this._characteristics[peripheralUuid][serviceUuid] = {};
-      this._descriptors[peripheralUuid][serviceUuid] = {};
-
-      services.push(service);
+      // don't wipe out services and things farther down the tree if they already exist.
+      if (typeof this._services[peripheralUuid][serviceUuid] == 'undefined') {
+          var service = new Service(this, peripheralUuid, serviceUuid);
+          this._services[peripheralUuid][serviceUuid] = service;
+          this._characteristics[peripheralUuid][serviceUuid] = {};
+          this._descriptors[peripheralUuid][serviceUuid] = {};
+          services.push(service);
+      }
     }
 
-    peripheral.services = services;
+    // if peripheral services not init, do that now.
+    if (!peripheral.services)
+        peripheral.services = [];
 
-    peripheral.emit('servicesDiscover', services);
+    // add new items to the peripherals array
+    services.map(function(s) { peripheral.services.push(s) });
+
+    // always return a copy of the peripheral services.
+    var returnedServices = [];
+    peripheral.services.map(function(s) { returnedServices.push(s); });
+
+    peripheral.emit('servicesDiscover', returnedServices);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' services discover!');
   }
@@ -240,7 +251,9 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
     for (var i = 0; i < characteristics.length; i++) {
       var characteristicUuid = characteristics[i].uuid;
 
-      var characteristic = new Characteristic(
+      // only create a new characteristic if the one in this slot is not discovered
+      if (typeof this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] == 'undefined') {
+          var characteristic = new Characteristic(
                                 this,
                                 peripheralUuid,
                                 serviceUuid,
@@ -248,15 +261,23 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
                                 characteristics[i].properties
                             );
 
-      this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
-
-      characteristics_.push(characteristic);
+          this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
+          this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
+          characteristics_.push(characteristic);
+      }
     }
 
-    service.characteristics = characteristics_;
+    if (!service.characteristics) {
+        service.characteristics = [];
+    }
 
-    service.emit('characteristicsDiscover', characteristics_);
+    characteristics_.map(function(c) { service.characteristics.push(c) });
+
+    // return the current list of characteristics.
+    var returnedCharacteristics = [];
+    service.characteristics.map(function(s) { returnedCharacteristics.push(s); });
+
+    service.emit('characteristicsDiscover', returnedCharacteristics);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' characteristics discover!');
   }
@@ -335,7 +356,8 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
     for (var i = 0; i < descriptors.length; i++) {
       var descriptorUuid = descriptors[i];
 
-      var descriptor = new Descriptor(
+      if (typeof this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] == 'undefined') {
+          var descriptor = new Descriptor(
                             this,
                             peripheralUuid,
                             serviceUuid,
@@ -343,14 +365,23 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
                             descriptorUuid
                         );
 
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+          this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
 
-      descriptors_.push(descriptor);
+          descriptors_.push(descriptor);
+      }
     }
 
-    characteristic.descriptors = descriptors_;
+    if (!characteristic.descriptors) {
+        characteristic.descriptors = [];
+    }
 
-    characteristic.emit('descriptorsDiscover', descriptors_);
+    descriptors_.map(function(c) { characteristic.descriptors.push(c) });
+
+    // return the current list of characteristics.
+    var returnedDescriptors = [];
+    characteristics.descriptors.map(function(s) { returnedDescriptors.push(s); });
+
+    characteristic.emit('descriptorsDiscover', returnedDescriptors);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' descriptors discover!');
   }


### PR DESCRIPTION
This pull request changes the default behavior of the noble library to be non destructive when issuing queries to devices.  With this patch the services, characteristics and descriptors get tested for existance before being overwritten with a fresh empty object, if they already exist they remain and the current array is always returned.

I tested this against the CC2650 sensortag and am now able to maintain multiple open data streams simultaneously with the device while also doing other device queries without halting already existing notifications.