### PR TITLE
Preserve GATT structure across connections

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -5,6 +5,7 @@ var util = require('util');
 
 var AclStream = require('./acl-stream');
 var Gatt = require('./gatt');
+var GattStructure = require('./gatt-structure');
 var Gap = require('./gap');
 var Hci = require('./hci');
 var Signaling = require('./signaling');
@@ -22,6 +23,7 @@ var NobleBindings = function() {
 
   this._handles = {};
   this._gatts = {};
+  this._gattStructures = {};
   this._aclStreams = {};
   this._signalings = {};
 
@@ -184,9 +186,12 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
     uuid = address.split(':').join('').toLowerCase();
 
     var aclStream = new AclStream(this._hci, handle, this._hci.addressType, this._hci.address, addressType, address);
-    var gatt = new Gatt(address, aclStream);
-    var signaling = new Signaling(handle, aclStream);
 
+    if(!this._gattStructures.hasOwnProperty(uuid)) {
+      this._gattStructures[uuid] = new GattStructure();
+    }
+    var gatt = new Gatt(address, aclStream, this._gattStructures[uuid]);
+    var signaling = new Signaling(handle, aclStream);
     this._gatts[uuid] = this._gatts[handle] = gatt;
     this._signalings[uuid] = this._signalings[handle] = signaling;
     this._aclStreams[handle] = aclStream;

--- a/lib/hci-socket/gatt-structure.js
+++ b/lib/hci-socket/gatt-structure.js
@@ -1,0 +1,12 @@
+//
+// Gatt Structure Encapsulation
+//
+
+var GattStructure = function() {
+    this._services = {};
+    this._characteristics = {};
+    this._descriptors = {};
+};
+
+
+module.exports = GattStructure;

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -55,13 +55,13 @@ var GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
 
 var ATT_CID = 0x0004;
 
-var Gatt = function(address, aclStream) {
+var Gatt = function(address, aclStream, gattStructure) {
   this._address = address;
   this._aclStream = aclStream;
 
-  this._services = {};
-  this._characteristics = {};
-  this._descriptors = {};
+  this._services = gattStructure._services;
+  this._characteristics = gattStructure._characteristics;
+  this._descriptors = gattStructure._descriptors;
 
   this._currentCommand = null;
   this._commandQueue = [];


### PR DESCRIPTION
Running on Linux the GATT structure is currently not preserved after a disconnect. On OSX it's possible to scan for services, disconnect, reconnect and directly access characteristics without scanning for services again - simply by reusing the service and characteristic objects received from an earlier scan. The current version of noble unfortunately removes all internal references to services, characteristics, and descriptors for Linux after disconnect: After each connection the services have to be scanned again which costs time and battery life of the device. The code in this PR keeps the objects around and simply restores the references after a reconnect. (See also [#363](https://github.com/sandeepmistry/noble/issues/363).) 

The discussion happened quite some time ago but recently I had the opportunity to also test on OSX. The behavior is consistent between operating systems and compliant to the Bluetooth standard as far as possible without major changes to noble:
Typically the GATT structure is very stable and therefore the Bluetooth standard encourages reusing the GATT structure across connections. If the structure changes at any time the device has to notify the communication partner by an indication sent from the service changed characteristic (service 1801, characteristic 2a05). If this characteristic does not exist the structure is guaranteed to stay put. 

OSX does everything under the hood: We don't get access to the service 1800 and 1801 at all from noble or any other application. This probably means that OSX itself monitors for changed services. Therefore a completely consistent behavior between OSes would require a major rewrite for Linux which possibly breaks all applications that read service 1800 to get names etc. 

The next best thing is to leave everything to the application level: Any user of noble on Linux can subscribe to characteristic 2a05 and perform service discovery afterwards. (As in most cases the structure changes only with firmware upgrades an application would also get away without monitoring at all. But this would not be standards compliant.) 

This change helped a lot to increase battery life for my devices: I use a long running application to read environment data every 10 mins and I already get months of battery life out a coin cell.