### PR TITLE
Error handling

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -89,9 +89,14 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
   }
 };
 
-Noble.prototype.onScanStart = function(filterDuplicates) {
+Noble.prototype.onScanStart = function(error, filterDuplicates) {
+  if (error) {
+    this.emit('scanStart', error);
+    return;
+  }
+
   debug('scanStart');
-  this.emit('scanStart', filterDuplicates);
+  this.emit('scanStart', null, filterDuplicates);
 };
 
 Noble.prototype.stopScanning = function(callback) {
@@ -101,9 +106,10 @@ Noble.prototype.stopScanning = function(callback) {
   this._bindings.stopScanning();
 };
 
-Noble.prototype.onScanStop = function() {
+Noble.prototype.onScanStop = function(error) {
+  // TODO: check error
   debug('scanStop');
-  this.emit('scanStop');
+  this.emit('scanStop', null);
 };
 
 Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, advertisement, rssi) {
@@ -157,12 +163,13 @@ Noble.prototype.disconnect = function(peripheralUuid) {
   this._bindings.disconnect(peripheralUuid);
 };
 
-Noble.prototype.onDisconnect = function(peripheralUuid) {
+Noble.prototype.onDisconnect = function(error, peripheralUuid) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
     peripheral.state = 'disconnected';
-    peripheral.emit('disconnect');
+    peripheral.emit('disconnect', null);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' disconnected!');
   }
@@ -172,13 +179,14 @@ Noble.prototype.updateRssi = function(peripheralUuid) {
   this._bindings.updateRssi(peripheralUuid);
 };
 
-Noble.prototype.onRssiUpdate = function(peripheralUuid, rssi) {
+Noble.prototype.onRssiUpdate = function(error, peripheralUuid, rssi) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
     peripheral.rssi = rssi;
 
-    peripheral.emit('rssiUpdate', rssi);
+    peripheral.emit('rssiUpdate', null, rssi);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' RSSI update!');
   }
@@ -188,7 +196,8 @@ Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
   this._bindings.discoverServices(peripheralUuid, uuids);
 };
 
-Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
+Noble.prototype.onServicesDiscover = function(error, peripheralUuid, serviceUuids) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
@@ -207,7 +216,7 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
 
     peripheral.services = services;
 
-    peripheral.emit('servicesDiscover', services);
+    peripheral.emit('servicesDiscover', null, services);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' services discover!');
   }
@@ -217,13 +226,14 @@ Noble.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid,
   this._bindings.discoverIncludedServices(peripheralUuid, serviceUuid, serviceUuids);
 };
 
-Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUuid, includedServiceUuids) {
+Noble.prototype.onIncludedServicesDiscover = function(error, peripheralUuid, serviceUuid, includedServiceUuids) {
+  // TODO: check error
   var service = this._services[peripheralUuid][serviceUuid];
 
   if (service) {
     service.includedServiceUuids = includedServiceUuids;
 
-    service.emit('includedServicesDiscover', includedServiceUuids);
+    service.emit('includedServicesDiscover', null, includedServiceUuids);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' included services discover!');
   }
@@ -233,7 +243,8 @@ Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, 
   this._bindings.discoverCharacteristics(peripheralUuid, serviceUuid, characteristicUuids);
 };
 
-Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid, characteristics) {
+Noble.prototype.onCharacteristicsDiscover = function(error, peripheralUuid, serviceUuid, characteristics) {
+  // TODO: check error
   var service = this._services[peripheralUuid][serviceUuid];
 
   if (service) {
@@ -258,7 +269,7 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
 
     service.characteristics = characteristics_;
 
-    service.emit('characteristicsDiscover', characteristics_);
+    service.emit('characteristicsDiscover', null, characteristics_);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' characteristics discover!');
   }
@@ -268,14 +279,15 @@ Noble.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid)
    this._bindings.read(peripheralUuid, serviceUuid, characteristicUuid);
 };
 
-Noble.prototype.onRead = function(peripheralUuid, serviceUuid, characteristicUuid, data, isNotification) {
+Noble.prototype.onRead = function(error, peripheralUuid, serviceUuid, characteristicUuid, data, isNotification) {
+  // TODO: check error
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
-    characteristic.emit('data', data, isNotification);
+    characteristic.emit('data', null, data, isNotification);
 
     if (!isNotification) {
-      characteristic.emit('read', data, isNotification); // for backwards compatbility
+      characteristic.emit('read', null, data, isNotification); // for backwards compatbility
     }
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' read!');
@@ -286,11 +298,12 @@ Noble.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid
    this._bindings.write(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse);
 };
 
-Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid) {
+Noble.prototype.onWrite = function(error, peripheralUuid, serviceUuid, characteristicUuid) {
+  // TODO: check error
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
-    characteristic.emit('write');
+    characteristic.emit('write', null);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' write!');
   }
@@ -300,11 +313,12 @@ Noble.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristic
    this._bindings.broadcast(peripheralUuid, serviceUuid, characteristicUuid, broadcast);
 };
 
-Noble.prototype.onBroadcast = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
+Noble.prototype.onBroadcast = function(error, peripheralUuid, serviceUuid, characteristicUuid, state) {
+  // TODO: check error
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
-    characteristic.emit('broadcast', state);
+    characteristic.emit('broadcast', null, state);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' broadcast!');
   }
@@ -314,11 +328,12 @@ Noble.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUui
    this._bindings.notify(peripheralUuid, serviceUuid, characteristicUuid, notify);
 };
 
-Noble.prototype.onNotify = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
+Noble.prototype.onNotify = function(error, peripheralUuid, serviceUuid, characteristicUuid, state) {
+  // TODO: check error
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
-    characteristic.emit('notify', state);
+    characteristic.emit('notify', null, state);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' notify!');
   }
@@ -328,7 +343,8 @@ Noble.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, char
   this._bindings.discoverDescriptors(peripheralUuid, serviceUuid, characteristicUuid);
 };
 
-Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, characteristicUuid, descriptors) {
+Noble.prototype.onDescriptorsDiscover = function(error, peripheralUuid, serviceUuid, characteristicUuid, descriptors) {
+  // TODO: check error
   var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
 
   if (characteristic) {
@@ -352,7 +368,7 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
 
     characteristic.descriptors = descriptors_;
 
-    characteristic.emit('descriptorsDiscover', descriptors_);
+    characteristic.emit('descriptorsDiscover', null, descriptors_);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' descriptors discover!');
   }
@@ -362,11 +378,12 @@ Noble.prototype.readValue = function(peripheralUuid, serviceUuid, characteristic
   this._bindings.readValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
 };
 
-Noble.prototype.onValueRead = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+Noble.prototype.onValueRead = function(error, peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+  // TODO: check error
   var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
 
   if (descriptor) {
-    descriptor.emit('valueRead', data);
+    descriptor.emit('valueRead', null, data);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value read!');
   }
@@ -376,11 +393,12 @@ Noble.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristi
   this._bindings.writeValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
 };
 
-Noble.prototype.onValueWrite = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+Noble.prototype.onValueWrite = function(error, peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+  // TODO: check error
   var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
 
   if (descriptor) {
-    descriptor.emit('valueWrite');
+    descriptor.emit('valueWrite', null);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value write!');
   }
@@ -390,11 +408,12 @@ Noble.prototype.readHandle = function(peripheralUuid, handle) {
   this._bindings.readHandle(peripheralUuid, handle);
 };
 
-Noble.prototype.onHandleRead = function(peripheralUuid, handle, data) {
+Noble.prototype.onHandleRead = function(error, peripheralUuid, handle, data) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
-    peripheral.emit('handleRead' + handle, data);
+    peripheral.emit('handleRead' + handle, null, data);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle read!');
   }
@@ -404,21 +423,23 @@ Noble.prototype.writeHandle = function(peripheralUuid, handle, data, withoutResp
   this._bindings.writeHandle(peripheralUuid, handle, data, withoutResponse);
 };
 
-Noble.prototype.onHandleWrite = function(peripheralUuid, handle) {
+Noble.prototype.onHandleWrite = function(error, peripheralUuid, handle) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
-    peripheral.emit('handleWrite' + handle);
+    peripheral.emit('handleWrite' + handle, null);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle write!');
   }
 };
 
-Noble.prototype.onHandleNotify = function(peripheralUuid, handle, data) {
+Noble.prototype.onHandleNotify = function(error, peripheralUuid, handle, data) {
+  // TODO: check error
   var peripheral = this._peripherals[peripheralUuid];
 
   if (peripheral) {
-    peripheral.emit('handleNotify', handle, data);
+    peripheral.emit('handleNotify', null, handle, data);
   } else {
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ' handle notify!');
   }


### PR DESCRIPTION
WIP.

Currently, no attempts are made to pass errors back up the chain to integrating developer. Any bluetooth related errors are going to happen within `bindings`, which means `bindings` need a way to send an error (or `null` when successful) back to `noble`, and `noble` back `peripheral`/`characteristic`/etc.

This has been brought a number of times; a few of them: https://github.com/sandeepmistry/noble/issues/276 https://github.com/sandeepmistry/noble/issues/207 https://github.com/sandeepmistry/noble/issues/184 https://github.com/sandeepmistry/noble/pull/536

I'd like to get some feedback on this approach before finishing it off. To finish, I'd need to:
1. check for error param in `noble`'s `bindings` listeners and `emit` corresponding event with `error` set
2. update all `bindings`' `emit`s to set `error` to `null` (or actually send the `error` for ones already catching errors)
3. update objects (`peripheral`/`characteristic`/etc) to check for `error` param and invoke callback accordingly
