### PR TITLE
More descriptive error outputs

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -214,8 +214,10 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
     this._gatts[handle].exchangeMtu(256);
   } else {
     uuid = this._pendingConnectionUuid;
-    var errorCode = status.toString(16);
-    error = new Error('HCI Error: (0x' + errorCode +  ') ' + Hci.STATUS_MAPPER[status] || ('HCI Error: Unknown (' + status + ')'));
+    var statusMessage = Hci.STATUS_MAPPER[status] || 'HCI Error: Unknown';
+    var errorCode = ' (0x' + status.toString(16) + ')';
+    statusMessage = statusMessage + errorCode;
+    error = new Error(statusMessage);
   }
 
   this.emit('connect', uuid, error);

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -214,8 +214,8 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
     this._gatts[handle].exchangeMtu(256);
   } else {
     uuid = this._pendingConnectionUuid;
-
-    error = new Error(Hci.STATUS_MAPPER[status] || ('Unknown (' + status + ')'));
+    var errorCode = status.toString(16);
+    error = new Error('HCI Error: (0x' + errorCode +  ') ' + Hci.STATUS_MAPPER[status] || ('HCI Error: Unknown (' + status + ')'));
   }
 
   this.emit('connect', uuid, error);


### PR DESCRIPTION
As helpful as it is to have the Status Mapper print out plain english error codes, It might also be nice to give users the HCI error code they're dealing with.  I found [this table](http://www.lisha.ufsc.br/teaching/shi/ine5346-2003-1/work/bluetooth/hci_commands.html) which seems to mirror what's returned in that status field - so in this PR, I convert `status` to a hex string and spit it out with the plaintext.