### PR TITLE
noble.stop() function

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -105,6 +105,11 @@ Hci.prototype.init = function() {
   }
 };
 
+Hci.prototype.stop = function() {
+    this._socket.stop();
+    clearTimeout(this._pollIsDevUpTimeout);
+}
+
 Hci.prototype.pollIsDevUp = function() {
   var isDevUp = this._socket.isDevUp();
 
@@ -124,7 +129,7 @@ Hci.prototype.pollIsDevUp = function() {
     this._isDevUp = isDevUp;
   }
 
-  setTimeout(this.pollIsDevUp.bind(this), 1000);
+  this._pollIsDevUpTimeout = setTimeout(this.pollIsDevUp.bind(this), 1000);
 };
 
 Hci.prototype.setSocketFilter = function() {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -52,6 +52,10 @@ function Noble(bindings) {
 
 util.inherits(Noble, events.EventEmitter);
 
+Noble.prototype.stop = function() {
+  this._bindings._hci.stop();
+};
+
 Noble.prototype.onStateChange = function(state) {
   debug('stateChange ' + state);
 


### PR DESCRIPTION
Lousy first try at implementing a noble.stop() function, as requested in #299 
Probably doesn't even work correctly; I just fiddled around until the test program:
```
noble = require('noble');
noble.stop()
```
seemed to somehow work. Might still be useful as a kind of starting point for a proper stop() function.