### PR TITLE
linux-bluez5 Branch: fix a typo in linux-bindings

### DIFF
--- a/lib/linux-bindings.js
+++ b/lib/linux-bindings.js
@@ -107,7 +107,7 @@ nobleBindings.connect = function(peripheralUuid) {
 nobleBindings.disconnect = function(peripheralUuid) {
   var deviceInterface = this._devices[peripheralUuid];
 
-  deviceInterface.Disonnect();
+  deviceInterface.Disconnect();
 };
 
 nobleBindings.updateRssi = function(peripheralUuid) {


### PR DESCRIPTION
Not that I'm watching your every move, @sandeepmistry - but I spotted a typo in one of your working branches while I was out scouring for support for bluez5.  

How is this branch coming along? Do you think support for bluez5 will be included in a release soon?