### PR TITLE
Allow duplicate uuid's for services, characteristics, and descriptors.

### DIFF
--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -5,11 +5,13 @@ var util = require('util');
 
 var characteristics = require('./characteristics.json');
 
-function Characteristic(noble, peripheralId, serviceUuid, uuid, properties) {
+function Characteristic(noble, peripheralId, serviceId, serviceUuid, id, uuid, properties) {
   this._noble = noble;
   this._peripheralId = peripheralId;
+  this._serviceId = serviceId;
   this._serviceUuid = serviceUuid;
 
+  this.id = id;
   this.uuid = uuid;
   this.name = null;
   this.type = null;
@@ -27,6 +29,7 @@ util.inherits(Characteristic, events.EventEmitter);
 
 Characteristic.prototype.toString = function() {
   return JSON.stringify({
+    id: this.id,
     uuid: this.uuid,
     name: this.name,
     type: this.type,
@@ -53,8 +56,8 @@ Characteristic.prototype.read = function(callback) {
 
   this._noble.read(
     this._peripheralId,
-    this._serviceUuid,
-    this.uuid
+    this._serviceId,
+    this.id
   );
 };
 
@@ -73,8 +76,8 @@ Characteristic.prototype.write = function(data, withoutResponse, callback) {
 
   this._noble.write(
     this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
+    this._serviceId,
+    this.id,
     data,
     withoutResponse
   );
@@ -89,8 +92,8 @@ Characteristic.prototype.broadcast = function(broadcast, callback) {
 
   this._noble.broadcast(
     this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
+    this._serviceId,
+    this.id,
     broadcast
   );
 };
@@ -105,8 +108,8 @@ Characteristic.prototype.notify = function(notify, callback) {
 
   this._noble.notify(
     this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
+    this._serviceId,
+    this.id,
     notify
   );
 };
@@ -128,8 +131,8 @@ Characteristic.prototype.discoverDescriptors = function(callback) {
 
   this._noble.discoverDescriptors(
     this._peripheralId,
-    this._serviceUuid,
-    this.uuid
+    this._serviceId,
+    this.id
   );
 };
 

--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -5,12 +5,15 @@ var util = require('util');
 
 var descriptors = require('./descriptors.json');
 
-function Descriptor(noble, peripheralId, serviceUuid, characteristicUuid, uuid) {
+function Descriptor(noble, peripheralId, serviceId, serviceUuid, characteristicId, characteristicUuid, id, uuid) {
   this._noble = noble;
   this._peripheralId = peripheralId;
+  this._serviceId = serviceId;
   this._serviceUuid = serviceUuid;
+  this._characteristicId = characteristicId;
   this._characteristicUuid = characteristicUuid;
 
+  this.id = id;
   this.uuid = uuid;
   this.name = null;
   this.type = null;
@@ -26,6 +29,7 @@ util.inherits(Descriptor, events.EventEmitter);
 
 Descriptor.prototype.toString = function() {
   return JSON.stringify({
+    id: this.id,
     uuid: this.uuid,
     name: this.name,
     type: this.type
@@ -40,9 +44,9 @@ Descriptor.prototype.readValue = function(callback) {
   }
   this._noble.readValue(
     this._peripheralId,
-    this._serviceUuid,
-    this._characteristicUuid,
-    this.uuid
+    this._serviceId,
+    this._characteristicId,
+    this.id
   );
 };
 
@@ -58,9 +62,9 @@ Descriptor.prototype.writeValue = function(data, callback) {
   }
   this._noble.writeValue(
     this._peripheralId,
-    this._serviceUuid,
-    this._characteristicUuid,
-    this.uuid,
+    this._serviceId,
+    this._characteristicId,
+    this.id,
     data
   );
 };

--- a/lib/distributed/bindings.js
+++ b/lib/distributed/bindings.js
@@ -60,15 +60,15 @@ NobleBindings.prototype._onMessage = function(ws, event) {
   var advertisement = event.advertisement;
   var rssi = event.rssi;
   var serviceUuids = event.serviceUuids;
-  var serviceUuid = event.serviceUuid;
+  var serviceId = event.serviceId;
   var includedServiceUuids = event.includedServiceUuids;
   var characteristics = event.characteristics;
-  var characteristicUuid = event.characteristicUuid;
+  var characteristicId = event.characteristicId;
   var data = event.data ? new Buffer(event.data, 'hex') : null;
   var isNotification = event.isNotification;
   var state = event.state;
   var descriptors = event.descriptors;
-  var descriptorUuid = event.descriptorUuid;
+  var descriptorId = event.descriptorId;
   var handle = event.handle;
 
   if (type === 'discover') {
@@ -99,23 +99,23 @@ NobleBindings.prototype._onMessage = function(ws, event) {
   } else if (type === 'servicesDiscover') {
     this.emit('servicesDiscover', peripheralUuid, serviceUuids);
   } else if (type === 'includedServicesDiscover') {
-    this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+    this.emit('includedServicesDiscover', peripheralUuid, serviceId, includedServiceUuids);
   } else if (type === 'characteristicsDiscover') {
-    this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+    this.emit('characteristicsDiscover', peripheralUuid, serviceId, characteristics);
   } else if (type === 'read') {
-    this.emit('read', peripheralUuid, serviceUuid, characteristicUuid, data, isNotification);
+    this.emit('read', peripheralUuid, serviceId, characteristicId, data, isNotification);
   } else if (type === 'write') {
-    this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralUuid, serviceId, characteristicId);
   } else if (type === 'broadcast') {
-    this.emit('broadcast', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('broadcast', peripheralUuid, serviceId, characteristicId, state);
   } else if (type === 'notify') {
-    this.emit('notify', peripheralUuid, serviceUuid, characteristicUuid, state);
+    this.emit('notify', peripheralUuid, serviceId, characteristicId, state);
   } else if (type === 'descriptorsDiscover') {
-    this.emit('descriptorsDiscover', peripheralUuid, serviceUuid, characteristicUuid, descriptors);
+    this.emit('descriptorsDiscover', peripheralUuid, serviceId, characteristicId, descriptors);
   } else if (type === 'valueRead') {
-    this.emit('valueRead', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+    this.emit('valueRead', peripheralUuid, serviceId, characteristicId, descriptorId, data);
   } else if (type === 'valueWrite') {
-    this.emit('valueWrite', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+    this.emit('valueWrite', peripheralUuid, serviceId, characteristicId, descriptorId);
   } else if (type === 'handleRead') {
     this.emit('handleRead', peripheralUuid, handle, data);
   } else if (type === 'handleWrite') {
@@ -194,108 +194,108 @@ NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
   });
 };
 
-NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
+NobleBindings.prototype.discoverIncludedServices = function(deviceUuid, serviceId, serviceUuids) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverIncludedServices',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
+    serviceId: serviceId,
     serviceUuids: serviceUuids
   });
 };
 
-NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
+NobleBindings.prototype.discoverCharacteristics = function(deviceUuid, serviceId, characteristicUuids) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverCharacteristics',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
+    serviceId: serviceId,
     characteristicUuids: characteristicUuids
   });
 };
 
-NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.read = function(deviceUuid, serviceId, characteristicId) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'read',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid
+    serviceId: serviceId,
+    characteristicId: characteristicId
   });
 };
 
-NobleBindings.prototype.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+NobleBindings.prototype.write = function(deviceUuid, serviceId, characteristicId, data, withoutResponse) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'write',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid,
+    serviceId: serviceId,
+    characteristicId: characteristicId,
     data: data.toString('hex'),
     withoutResponse: withoutResponse
   });
 };
 
-NobleBindings.prototype.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+NobleBindings.prototype.broadcast = function(deviceUuid, serviceId, characteristicId, broadcast) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'broadcast',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid,
+    serviceId: serviceId,
+    characteristicId: characteristicId,
     broadcast: broadcast
   });
 };
 
-NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+NobleBindings.prototype.notify = function(deviceUuid, serviceId, characteristicId, notify) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'notify',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid,
+    serviceId: serviceId,
+    characteristicId: characteristicId,
     notify: notify
   });
 };
 
-NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.discoverDescriptors = function(deviceUuid, serviceId, characteristicId) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'discoverDescriptors',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid
+    serviceId: serviceId,
+    characteristicId: characteristicId
   });
 };
 
-NobleBindings.prototype.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+NobleBindings.prototype.readValue = function(deviceUuid, serviceId, characteristicId, descriptorId) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'readValue',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid,
-    descriptorUuid: descriptorUuid
+    serviceId: serviceId,
+    characteristicId: characteristicId,
+    descriptorId: descriptorId
   });
 };
 
-NobleBindings.prototype.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+NobleBindings.prototype.writeValue = function(deviceUuid, serviceId, characteristicId, descriptorId, data) {
   var peripheral = this._peripherals[deviceUuid];
 
   this._sendCommand(peripheral.ws, {
     action: 'writeValue',
     peripheralUuid: peripheral.uuid,
-    serviceUuid: serviceUuid,
-    characteristicUuid: characteristicUuid,
-    descriptorUuid: descriptorUuid,
+    serviceId: serviceId,
+    characteristicId: characteristicId,
+    descriptorId: descriptorId,
     data: data.toString('hex')
   });
 };

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -299,169 +299,169 @@ NobleBindings.prototype.discoverServices = function(peripheralUuid, uuids) {
   }
 };
 
-NobleBindings.prototype.onServicesDiscovered = function(address, serviceUuids) {
+NobleBindings.prototype.onServicesDiscovered = function(address, serviceIds) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('servicesDiscover', uuid, serviceUuids);
+  this.emit('servicesDiscover', uuid, serviceIds);
 };
 
-NobleBindings.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
+NobleBindings.prototype.discoverIncludedServices = function(peripheralUuid, serviceId, serviceUuids) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.discoverIncludedServices(serviceUuid, serviceUuids || []);
+    gatt.discoverIncludedServices(serviceId, serviceUuids || []);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onIncludedServicesDiscovered = function(address, serviceUuid, includedServiceUuids) {
+NobleBindings.prototype.onIncludedServicesDiscovered = function(address, serviceId, includedServiceIds) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('includedServicesDiscover', uuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', uuid, serviceId, includedServiceIds);
 };
 
-NobleBindings.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
+NobleBindings.prototype.discoverCharacteristics = function(peripheralUuid, serviceId, characteristicUuids) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.discoverCharacteristics(serviceUuid, characteristicUuids || []);
+    gatt.discoverCharacteristics(serviceId, characteristicUuids || []);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onCharacteristicsDiscovered = function(address, serviceUuid, characteristics) {
+NobleBindings.prototype.onCharacteristicsDiscovered = function(address, serviceId, characteristics) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('characteristicsDiscover', uuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', uuid, serviceId, characteristics);
 };
 
-NobleBindings.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.read = function(peripheralUuid, serviceId, characteristicId) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.read(serviceUuid, characteristicUuid);
+    gatt.read(serviceId, characteristicId);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onRead = function(address, serviceUuid, characteristicUuid, data) {
+NobleBindings.prototype.onRead = function(address, serviceId, characteristicId, data) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('read', uuid, serviceUuid, characteristicUuid, data, false);
+  this.emit('read', uuid, serviceId, characteristicId, data, false);
 };
 
-NobleBindings.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+NobleBindings.prototype.write = function(peripheralUuid, serviceId, characteristicId, data, withoutResponse) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.write(serviceUuid, characteristicUuid, data, withoutResponse);
+    gatt.write(serviceId, characteristicId, data, withoutResponse);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onWrite = function(address, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.onWrite = function(address, serviceId, characteristicId) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('write', uuid, serviceUuid, characteristicUuid);
+  this.emit('write', uuid, serviceId, characteristicId);
 };
 
-NobleBindings.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
+NobleBindings.prototype.broadcast = function(peripheralUuid, serviceId, characteristicId, broadcast) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.broadcast(serviceUuid, characteristicUuid, broadcast);
+    gatt.broadcast(serviceId, characteristicId, broadcast);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onBroadcast = function(address, serviceUuid, characteristicUuid, state) {
+NobleBindings.prototype.onBroadcast = function(address, serviceId, characteristicId, state) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('broadcast', uuid, serviceUuid, characteristicUuid, state);
+  this.emit('broadcast', uuid, serviceId, characteristicId, state);
 };
 
-NobleBindings.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
+NobleBindings.prototype.notify = function(peripheralUuid, serviceId, characteristicId, notify) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.notify(serviceUuid, characteristicUuid, notify);
+    gatt.notify(serviceId, characteristicId, notify);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onNotify = function(address, serviceUuid, characteristicUuid, state) {
+NobleBindings.prototype.onNotify = function(address, serviceId, characteristicId, state) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('notify', uuid, serviceUuid, characteristicUuid, state);
+  this.emit('notify', uuid, serviceId, characteristicId, state);
 };
 
-NobleBindings.prototype.onNotification = function(address, serviceUuid, characteristicUuid, data) {
+NobleBindings.prototype.onNotification = function(address, serviceId, characteristicId, data) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('read', uuid, serviceUuid, characteristicUuid, data, true);
+  this.emit('read', uuid, serviceId, characteristicId, data, true);
 };
 
-NobleBindings.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.discoverDescriptors = function(peripheralUuid, serviceId, characteristicId) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.discoverDescriptors(serviceUuid, characteristicUuid);
+    gatt.discoverDescriptors(serviceId, characteristicId);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onDescriptorsDiscovered = function(address, serviceUuid, characteristicUuid, descriptorUuids) {
+NobleBindings.prototype.onDescriptorsDiscovered = function(address, serviceId, characteristicId, descriptorIds) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('descriptorsDiscover', uuid, serviceUuid, characteristicUuid, descriptorUuids);
+  this.emit('descriptorsDiscover', uuid, serviceId, characteristicId, descriptorIds);
 };
 
-NobleBindings.prototype.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+NobleBindings.prototype.readValue = function(peripheralUuid, serviceId, characteristicId, descriptorId) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.readValue(serviceUuid, characteristicUuid, descriptorUuid);
+    gatt.readValue(serviceId, characteristicId, descriptorId);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onValueRead = function(address, serviceUuid, characteristicUuid, descriptorUuid, data) {
+NobleBindings.prototype.onValueRead = function(address, serviceId, characteristicId, descriptorId, data) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('valueRead', uuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+  this.emit('valueRead', uuid, serviceId, characteristicId, descriptorId, data);
 };
 
-NobleBindings.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+NobleBindings.prototype.writeValue = function(peripheralUuid, serviceId, characteristicId, descriptorId, data) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.writeValue(serviceUuid, characteristicUuid, descriptorUuid, data);
+    gatt.writeValue(serviceId, characteristicId, descriptorId, data);
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
 };
 
-NobleBindings.prototype.onValueWrite = function(address, serviceUuid, characteristicUuid, descriptorUuid) {
+NobleBindings.prototype.onValueWrite = function(address, serviceId, characteristicId, descriptorId) {
   var uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('valueWrite', uuid, serviceUuid, characteristicUuid, descriptorUuid);
+  this.emit('valueWrite', uuid, serviceId, characteristicId, descriptorId);
 };
 
 NobleBindings.prototype.readHandle = function(peripheralUuid, attHandle) {

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -55,7 +55,6 @@ var GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
 
 var ATT_CID = 0x0004;
 
-var serviceNum = 0;
 var Gatt = function(address, aclStream) {
   this._address = address;
   this._aclStream = aclStream;
@@ -342,9 +341,8 @@ Gatt.prototype.discoverServices = function(uuids) {
       var num = (data.length - 2) / type;
 
       for (i = 0; i < num; i++) {
-        serviceNum++;
         services.push({
-          id: 's:' + serviceNum,
+          id: data.readUInt16LE(2 + i * type + 0),
           startHandle: data.readUInt16LE(2 + i * type + 0),
           endHandle: data.readUInt16LE(2 + i * type + 2),
           uuid: (type == 6) ? data.readUInt16LE(2 + i * type + 4).toString(16) : data.slice(2 + i * type + 4).slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('')
@@ -384,7 +382,7 @@ Gatt.prototype.discoverIncludedServices = function(serviceId, uuids) {
 
       for (i = 0; i < num; i++) {
         includedServices.push({
-          id: 's:' + service.id + ':is:' + (i + 1),
+          id: data.readUInt16LE(2 + i * type + 2),
           endHandle: data.readUInt16LE(2 + i * type + 0),
           startHandle: data.readUInt16LE(2 + i * type + 2),
           uuid: (type == 8) ? data.readUInt16LE(2 + i * type + 6).toString(16) : data.slice(2 + i * type + 6).slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('')
@@ -427,7 +425,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceId, characteristicUuids
 
       for (i = 0; i < num; i++) {
         characteristics.push({
-          id: 's:' + service.id + ':char:' + (i + 1),
+          id: data.readUInt16LE(2 + i * type + 0),
           startHandle: data.readUInt16LE(2 + i * type + 0),
           properties: data.readUInt8(2 + i * type + 2),
           valueHandle: data.readUInt16LE(2 + i * type + 3),
@@ -676,7 +674,7 @@ Gatt.prototype.discoverDescriptors = function(serviceId, characteristicId) {
 
       for (i = 0; i < num; i++) {
         descriptors.push({
-          id: characteristic.id + ':desc:' + (i + 1),
+          id: data.readUInt16LE(2 + i * 4 + 0),
           handle: data.readUInt16LE(2 + i * 4 + 0),
           uuid: data.readUInt16LE(2 + i * 4 + 2).toString(16)
         });

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -55,6 +55,7 @@ var GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
 
 var ATT_CID = 0x0004;
 
+var serviceNum = 0;
 var Gatt = function(address, aclStream) {
   this._address = address;
   this._aclStream = aclStream;
@@ -109,10 +110,10 @@ Gatt.prototype.onAclStreamData = function(cid, data) {
       }.bind(this));
     }
 
-    for (var serviceUuid in this._services) {
-      for (var characteristicUuid in this._characteristics[serviceUuid]) {
-        if (this._characteristics[serviceUuid][characteristicUuid].valueHandle === valueHandle) {
-          this.emit('notification', this._address, serviceUuid, characteristicUuid, valueData);
+    for (var serviceId in this._services) {
+      for (var characteristicId in this._characteristics[serviceId]) {
+        if (this._characteristics[serviceId][characteristicId].valueHandle === valueHandle) {
+          this.emit('notification', this._address, serviceId, characteristicId, valueData);
         }
       }
     }
@@ -341,7 +342,9 @@ Gatt.prototype.discoverServices = function(uuids) {
       var num = (data.length - 2) / type;
 
       for (i = 0; i < num; i++) {
+        serviceNum++;
         services.push({
+          id: 's:' + serviceNum,
           startHandle: data.readUInt16LE(2 + i * type + 0),
           endHandle: data.readUInt16LE(2 + i * type + 2),
           uuid: (type == 6) ? data.readUInt16LE(2 + i * type + 4).toString(16) : data.slice(2 + i * type + 4).slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('')
@@ -350,15 +353,15 @@ Gatt.prototype.discoverServices = function(uuids) {
     }
 
     if (opcode !== ATT_OP_READ_BY_GROUP_RESP || services[services.length - 1].endHandle === 0xffff) {
-      var serviceUuids = [];
+      var serviceIds = [];
       for (i = 0; i < services.length; i++) {
         if (uuids.length === 0 || uuids.indexOf(services[i].uuid) !== -1) {
-          serviceUuids.push(services[i].uuid);
+          serviceIds.push({ uuid: services[i].uuid, id: services[i].id });
         }
 
-        this._services[services[i].uuid] = services[i];
+        this._services[services[i].id] = services[i];
       }
-      this.emit('servicesDiscover', this._address, serviceUuids);
+      this.emit('servicesDiscover', this._address, serviceIds);
     } else {
       this._queueCommand(this.readByGroupRequest(services[services.length - 1].endHandle + 1, 0xffff, GATT_PRIM_SVC_UUID), callback);
     }
@@ -367,8 +370,8 @@ Gatt.prototype.discoverServices = function(uuids) {
   this._queueCommand(this.readByGroupRequest(0x0001, 0xffff, GATT_PRIM_SVC_UUID), callback);
 };
 
-Gatt.prototype.discoverIncludedServices = function(serviceUuid, uuids) {
-  var service = this._services[serviceUuid];
+Gatt.prototype.discoverIncludedServices = function(serviceId, uuids) {
+  var service = this._services[serviceId];
   var includedServices = [];
 
   var callback = function(data) {
@@ -381,6 +384,7 @@ Gatt.prototype.discoverIncludedServices = function(serviceUuid, uuids) {
 
       for (i = 0; i < num; i++) {
         includedServices.push({
+          id: 's:' + service.id + ':is:' + (i + 1),
           endHandle: data.readUInt16LE(2 + i * type + 0),
           startHandle: data.readUInt16LE(2 + i * type + 2),
           uuid: (type == 8) ? data.readUInt16LE(2 + i * type + 6).toString(16) : data.slice(2 + i * type + 6).slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('')
@@ -392,12 +396,12 @@ Gatt.prototype.discoverIncludedServices = function(serviceUuid, uuids) {
       var includedServiceUuids = [];
 
       for (i = 0; i < includedServices.length; i++) {
-        if (uuids.length === 0 || uuids.indexOf(includedServices[i].uuid) !== -1) {
+        if (uuids.length === 0 || (uuids.indexOf(includedServices[i].uuid) !== -1 && includedServiceUuids.indexOf(includedServices[i].uuid) === -1)) {
           includedServiceUuids.push(includedServices[i].uuid);
         }
       }
 
-      this.emit('includedServicesDiscover', this._address, service.uuid, includedServiceUuids);
+      this.emit('includedServicesDiscover', this._address, service.id, includedServiceUuids);
     } else {
       this._queueCommand(this.readByTypeRequest(includedServices[includedServices.length - 1].endHandle + 1, service.endHandle, GATT_INCLUDE_UUID), callback);
     }
@@ -406,12 +410,12 @@ Gatt.prototype.discoverIncludedServices = function(serviceUuid, uuids) {
   this._queueCommand(this.readByTypeRequest(service.startHandle, service.endHandle, GATT_INCLUDE_UUID), callback);
 };
 
-Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUuids) {
-  var service = this._services[serviceUuid];
+Gatt.prototype.discoverCharacteristics = function(serviceId, characteristicUuids) {
+  var service = this._services[serviceId];
   var characteristics = [];
 
-  this._characteristics[serviceUuid] = {};
-  this._descriptors[serviceUuid] = this._descriptors[serviceUuid] || {};
+  this._characteristics[serviceId] = {};
+  this._descriptors[serviceId] = this._descriptors[serviceId] || {};
 
   var callback = function(data) {
     var opcode = data[0];
@@ -423,6 +427,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
 
       for (i = 0; i < num; i++) {
         characteristics.push({
+          id: 's:' + service.id + ':char:' + (i + 1),
           startHandle: data.readUInt16LE(2 + i * type + 0),
           properties: data.readUInt8(2 + i * type + 2),
           valueHandle: data.readUInt16LE(2 + i * type + 3),
@@ -439,6 +444,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
 
         var characteristic = {
           properties: [],
+          id: characteristics[i].id,
           uuid: characteristics[i].uuid
         };
 
@@ -450,7 +456,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
           characteristics[i].endHandle = service.endHandle;
         }
 
-        this._characteristics[serviceUuid][characteristics[i].uuid] = characteristics[i];
+        this._characteristics[serviceId][characteristics[i].id] = characteristics[i];
 
         if (properties & 0x01) {
           characteristic.properties.push('broadcast');
@@ -484,12 +490,12 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
           characteristic.properties.push('extendedProperties');
         }
 
-        if (characteristicUuids.length === 0 || characteristicUuids.indexOf(characteristic.uuid) !== -1) {
+        if (characteristicUuids.length === 0 || (characteristicUuids.indexOf(characteristic.uuid) !== -1 && characteristicsDiscovered.indexOf(characteristics.uuid) === -1)) {
           characteristicsDiscovered.push(characteristic);
         }
       }
 
-      this.emit('characteristicsDiscover', this._address, serviceUuid, characteristicsDiscovered);
+      this.emit('characteristicsDiscover', this._address, serviceId, characteristicsDiscovered);
     } else {
       this._queueCommand(this.readByTypeRequest(characteristics[characteristics.length - 1].valueHandle + 1, service.endHandle, GATT_CHARAC_UUID), callback);
     }
@@ -498,8 +504,8 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
   this._queueCommand(this.readByTypeRequest(service.startHandle, service.endHandle, GATT_CHARAC_UUID), callback);
 };
 
-Gatt.prototype.read = function(serviceUuid, characteristicUuid) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.read = function(serviceId, characteristicId) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
 
   var readData = new Buffer(0);
 
@@ -512,39 +518,39 @@ Gatt.prototype.read = function(serviceUuid, characteristicUuid) {
       if (data.length === this._mtu) {
         this._queueCommand(this.readBlobRequest(characteristic.valueHandle, readData.length), callback);
       } else {
-        this.emit('read', this._address, serviceUuid, characteristicUuid, readData);
+        this.emit('read', this._address, serviceId, characteristicId, readData);
       }
     } else {
-      this.emit('read', this._address, serviceUuid, characteristicUuid, readData);
+      this.emit('read', this._address, serviceId, characteristicId, readData);
     }
   }.bind(this);
 
   this._queueCommand(this.readRequest(characteristic.valueHandle), callback);
 };
 
-Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutResponse) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.write = function(serviceId, characteristicId, data, withoutResponse) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
 
   if (withoutResponse) {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, true), null, function() {
-      this.emit('write', this._address, serviceUuid, characteristicUuid);
+      this.emit('write', this._address, serviceId, characteristicId);
     }.bind(this));
   } else if (data.length + 3 > this._mtu) {
-    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
+    return this.longWrite(serviceId, characteristicId, data, withoutResponse);
   } else {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, false), function(data) {
       var opcode = data[0];
 
       if (opcode === ATT_OP_WRITE_RESP) {
-        this.emit('write', this._address, serviceUuid, characteristicUuid);
+        this.emit('write', this._address, serviceId, characteristicId);
       }
     }.bind(this));
   }
 };
 
 /* Perform a "long write" as described Bluetooth Spec section 4.9.4 "Write Long Characteristic Values" */
-Gatt.prototype.longWrite = function(serviceUuid, characteristicUuid, data, withoutResponse) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.longWrite = function(serviceId, characteristicId, data, withoutResponse) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
   var limit = this._mtu - 5;
 
   var prepareWriteCallback = function(data_chunk) {
@@ -579,13 +585,13 @@ Gatt.prototype.longWrite = function(serviceUuid, characteristicUuid, data, witho
     var opcode = resp[0];
 
     if (opcode === ATT_OP_EXECUTE_WRITE_RESP && !withoutResponse) {
-      this.emit('write', this._address, serviceUuid, characteristicUuid);
+      this.emit('write', this._address, serviceId, characteristicId);
     }
   }.bind(this));
 };
 
-Gatt.prototype.broadcast = function(serviceUuid, characteristicUuid, broadcast) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.broadcast = function(serviceId, characteristicId, broadcast) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
 
   this._queueCommand(this.readByTypeRequest(characteristic.startHandle, characteristic.endHandle, GATT_SERVER_CHARAC_CFG_UUID), function(data) {
     var opcode = data[0];
@@ -607,15 +613,15 @@ Gatt.prototype.broadcast = function(serviceUuid, characteristicUuid, broadcast) 
         var opcode = data[0];
 
         if (opcode === ATT_OP_WRITE_RESP) {
-          this.emit('broadcast', this._address, serviceUuid, characteristicUuid, broadcast);
+          this.emit('broadcast', this._address, serviceId, characteristicId, broadcast);
         }
       }.bind(this));
     }
   }.bind(this));
 };
 
-Gatt.prototype.notify = function(serviceUuid, characteristicUuid, notify) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.notify = function(serviceId, characteristicId, notify) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
 
   this._queueCommand(this.readByTypeRequest(characteristic.startHandle, characteristic.endHandle, GATT_CLIENT_CHARAC_CFG_UUID), function(data) {
     var opcode = data[0];
@@ -648,18 +654,18 @@ Gatt.prototype.notify = function(serviceUuid, characteristicUuid, notify) {
         var opcode = data[0];
 
         if (opcode === ATT_OP_WRITE_RESP) {
-          this.emit('notify', this._address, serviceUuid, characteristicUuid, notify);
+          this.emit('notify', this._address, serviceId, characteristicId, notify);
         }
       }.bind(this));
     }
   }.bind(this));
 };
 
-Gatt.prototype.discoverDescriptors = function(serviceUuid, characteristicUuid) {
-  var characteristic = this._characteristics[serviceUuid][characteristicUuid];
+Gatt.prototype.discoverDescriptors = function(serviceId, characteristicId) {
+  var characteristic = this._characteristics[serviceId][characteristicId];
   var descriptors = [];
 
-  this._descriptors[serviceUuid][characteristicUuid] = {};
+  this._descriptors[serviceId][characteristicId] = {};
 
   var callback = function(data) {
     var opcode = data[0];
@@ -670,6 +676,7 @@ Gatt.prototype.discoverDescriptors = function(serviceUuid, characteristicUuid) {
 
       for (i = 0; i < num; i++) {
         descriptors.push({
+          id: characteristic.id + ':desc:' + (i + 1),
           handle: data.readUInt16LE(2 + i * 4 + 0),
           uuid: data.readUInt16LE(2 + i * 4 + 2).toString(16)
         });
@@ -677,14 +684,14 @@ Gatt.prototype.discoverDescriptors = function(serviceUuid, characteristicUuid) {
     }
 
     if (opcode !== ATT_OP_FIND_INFO_RESP || descriptors[descriptors.length - 1].handle === characteristic.endHandle) {
-      var descriptorUuids = [];
+      var descriptorIds = [];
       for (i = 0; i < descriptors.length; i++) {
-        descriptorUuids.push(descriptors[i].uuid);
+        descriptorIds.push({ uuid: descriptors[i].uuid, id: descriptors[i].id });
 
-        this._descriptors[serviceUuid][characteristicUuid][descriptors[i].uuid] = descriptors[i];
+        this._descriptors[serviceId][characteristicId][descriptors[i].id] = descriptors[i];
       }
 
-      this.emit('descriptorsDiscover', this._address, serviceUuid, characteristicUuid, descriptorUuids);
+      this.emit('descriptorsDiscover', this._address, serviceId, characteristicId, descriptorIds);
     } else {
       this._queueCommand(this.findInfoRequest(descriptors[descriptors.length - 1].handle + 1, characteristic.endHandle), callback);
     }
@@ -693,26 +700,26 @@ Gatt.prototype.discoverDescriptors = function(serviceUuid, characteristicUuid) {
   this._queueCommand(this.findInfoRequest(characteristic.valueHandle + 1, characteristic.endHandle), callback);
 };
 
-Gatt.prototype.readValue = function(serviceUuid, characteristicUuid, descriptorUuid) {
-  var descriptor = this._descriptors[serviceUuid][characteristicUuid][descriptorUuid];
+Gatt.prototype.readValue = function(serviceId, characteristicId, descriptorId) {
+  var descriptor = this._descriptors[serviceId][characteristicId][descriptorId];
 
   this._queueCommand(this.readRequest(descriptor.handle), function(data) {
     var opcode = data[0];
 
     if (opcode === ATT_OP_READ_RESP) {
-      this.emit('valueRead', this._address, serviceUuid, characteristicUuid, descriptorUuid, data.slice(1));
+      this.emit('valueRead', this._address, serviceId, characteristicId, descriptorId, data.slice(1));
     }
   }.bind(this));
 };
 
-Gatt.prototype.writeValue = function(serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var descriptor = this._descriptors[serviceUuid][characteristicUuid][descriptorUuid];
+Gatt.prototype.writeValue = function(serviceId, characteristicId, descriptorId, data) {
+  var descriptor = this._descriptors[serviceId][characteristicId][descriptorId];
 
   this._queueCommand(this.writeRequest(descriptor.handle, data, false), function(data) {
     var opcode = data[0];
 
     if (opcode === ATT_OP_WRITE_RESP) {
-      this.emit('valueWrite', this._address, serviceUuid, characteristicUuid, descriptorUuid);
+      this.emit('valueWrite', this._address, serviceId, characteristicId, descriptorId);
     }
   }.bind(this));
 };

--- a/lib/mac/legacy.js
+++ b/lib/mac/legacy.js
@@ -12,6 +12,7 @@ var uuidToAddress = require('./uuid-to-address');
 
 var XpcConnection = require('xpc-connection');
 
+var serviceNum = 0;
 var NobleBindings = function() {
   this._peripherals = {};
 
@@ -252,30 +253,31 @@ nobleBindings.discoverServices = function(peripheralUuid, uuids) {
 nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId21' : 'kCBMsgId42', function(args) {
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
   var peripheralUuid = this._peripherals[peripheralHandle].uuid;
-  var serviceUuids = [];
+  var serviceIds = [];
 
   this._peripherals[peripheralHandle].services = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var service = {
+      id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[peripheralHandle].services[service.uuid] = this._peripherals[peripheralHandle].services[service.startHandle] = service;
+    this._peripherals[peripheralHandle].services[service.startHandle] = service;
 
-    serviceUuids.push(service.uuid);
+    serviceIds.push({ uuid: service.uuid, id: service.id });
   }
 
-  this.emit('servicesDiscover', peripheralUuid, serviceUuids);
+  this.emit('servicesDiscover', peripheralUuid, serviceIds);
 });
 
-nobleBindings.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(peripheralUuid, serviceId, serviceUuids) {
   var args = {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -292,7 +294,6 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId27' : 'kCBMsgId48', function(args) 
   var peripheralUuidHandle = args.kCBMsgArgPeripheralHandle;
   var peripheralUuid = this._peripherals[peripheralUuidHandle].uuid;
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[peripheralUuidHandle].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
@@ -300,25 +301,25 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId27' : 'kCBMsgId48', function(args) 
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
+      id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[peripheralUuidHandle].services[serviceStartHandle].includedServices[includedService.startHandle] = includedService;
 
-    includedServiceUuids.push(includedService.uuid);
+    includedServiceUuids.push({ uuid: includedService.uuid, id: service.id });
   }
 
-  this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', peripheralUuid, serviceStartHandle, includedServiceUuids);
 });
 
-nobleBindings.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(peripheralUuid, serviceId, characteristicUuids) {
   var args = {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[peripheralUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[peripheralUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -335,7 +336,6 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId28' : 'kCBMsgId49', function(args) 
   var peripheralHandle = args.kCBMsgArgPeripheralHandle;
   var peripheralUuid = this._peripherals[peripheralHandle].uuid;
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[peripheralHandle].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
@@ -345,6 +345,7 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId28' : 'kCBMsgId49', function(args) 
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
 
     var characteristic = {
+      id: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       uuid: args.kCBMsgArgCharacteristics[i].kCBMsgArgUUID.toString('hex'),
       handle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       valueHandle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicValueHandle,
@@ -383,24 +384,24 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId28' : 'kCBMsgId49', function(args) 
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[peripheralHandle].services[serviceStartHandle].characteristics[characteristic.uuid] =
-      this._peripherals[peripheralHandle].services[serviceStartHandle].characteristics[characteristic.handle] =
+    this._peripherals[peripheralHandle].services[serviceStartHandle].characteristics[characteristic.handle] =
       this._peripherals[peripheralHandle].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
 
     characteristics.push({
+      id: characteristic.id,
       uuid: characteristic.uuid,
       properties: characteristic.properties
     });
   }
 
-  this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', peripheralUuid, serviceId, characteristics);
 });
 
-nobleBindings.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(peripheralUuid, serviceId, characteristicId) {
   this.sendCBMsg(isLessThan10_8_5 ? 29 : 50 , {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -418,8 +419,8 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId35' : 'kCBMsgId56', function(args) 
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', peripheralUuid, peripheral.services[i].uuid,
-          peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
+        this.emit('read', peripheralUuid, peripheral.services[i].id,
+          peripheral.services[i].characteristics[characteristicHandle].id, data, isNotification);
         break;
       }
     }
@@ -428,17 +429,17 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId35' : 'kCBMsgId56', function(args) 
   }
 });
 
-nobleBindings.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(peripheralUuid, serviceId, characteristicId, data, withoutResponse) {
   this.sendCBMsg(isLessThan10_8_5 ? 30 : 51, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    this.emit('write', peripheralUuid, serviceId, characteristicId);
   }
 };
 
@@ -451,18 +452,18 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId36' : 'kCBMsgId57', function(args) 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid);
+      this.emit('write', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].id);
       break;
     }
   }
 });
 
-nobleBindings.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(peripheralUuid, serviceId, characteristicId, broadcast) {
   this.sendCBMsg(isLessThan10_8_5 ? 31 : 52, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
@@ -477,18 +478,18 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId37' : 'kCBMsgId58', function(args) 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('broadcast', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
 });
 
-nobleBindings.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(peripheralUuid, serviceId, characteristicId, notify) {
   this.sendCBMsg(isLessThan10_8_5 ? 32 : 53, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
@@ -503,18 +504,18 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId38' : 'kCBMsgId59', function(args) 
   for(var i in this._peripherals[peripheralHandle].services) {
     if (this._peripherals[peripheralHandle].services[i].characteristics &&
         this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('notify', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
 });
 
-nobleBindings.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(peripheralUuid, serviceId, characteristicId) {
   this.sendCBMsg(isLessThan10_8_5 ? 34 : 55, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -533,27 +534,27 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId39' : 'kCBMsgId60', function(args) 
 
       for(var j = 0; j < args.kCBMsgArgDescriptors.length; j++) {
         var descriptor = {
+          id: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle,
           uuid: args.kCBMsgArgDescriptors[j].kCBMsgArgUUID.toString('hex'),
           handle: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle
         };
 
-        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
-          this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
+        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
 
-        descriptors.push(descriptor.uuid);
+        descriptors.push({ uuid: descriptor.uuid, id: descriptor.id });
       }
 
-      this.emit('descriptorsDiscover', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].uuid, descriptors);
+      this.emit('descriptorsDiscover', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+        this._peripherals[peripheralHandle].services[i].characteristics[characteristicHandle].id, descriptors);
       break;
     }
   }
 });
 
-nobleBindings.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(peripheralUuid, serviceId, characteristicId, descriptorId) {
   this.sendCBMsg(isLessThan10_8_5 ? 40 : 61, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle
   });
 };
 
@@ -571,19 +572,19 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId42' : 'kCBMsgId63', function(args) 
       if (this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors &&
         this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-          this._peripherals[peripheralHandle].services[i].characteristics[j].uuid,
-          this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
+        this.emit('valueRead', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+          this._peripherals[peripheralHandle].services[i].characteristics[j].id,
+          this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].id, data);
         return; // break;
       }
     }
   }
 });
 
-nobleBindings.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(peripheralUuid, serviceId, characteristicId, descriptorId, data) {
   this.sendCBMsg(isLessThan10_8_5 ? 41 : 62, {
     kCBMsgArgPeripheralHandle: this._peripherals[peripheralUuid].handle,
-    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgDescriptorHandle: this._peripherals[peripheralUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle,
     kCBMsgArgData: data
   });
 };
@@ -601,9 +602,9 @@ nobleBindings.on(isLessThan10_8_5 ? 'kCBMsgId43' : 'kCBMsgId64', function(args) 
       if (this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors &&
         this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', peripheralUuid, this._peripherals[peripheralHandle].services[i].uuid,
-          this._peripherals[peripheralHandle].services[i].characteristics[j].uuid,
-          this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
+        this.emit('valueWrite', peripheralUuid, this._peripherals[peripheralHandle].services[i].id,
+          this._peripherals[peripheralHandle].services[i].characteristics[j].id,
+          this._peripherals[peripheralHandle].services[i].characteristics[j].descriptors[descriptorHandle].id);
         return; // break;
       }
     }

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -228,33 +228,34 @@ nobleBindings.discoverServices = function(deviceUuid, uuids) {
 
 nobleBindings.on('kCBMsgId55', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
-  var serviceUuids = [];
+  var serviceIds = [];
 
   this._peripherals[deviceUuid].services = {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
       var service = {
+        id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      this._peripherals[deviceUuid].services[service.startHandle] = service;
 
-      serviceUuids.push(service.uuid);
+      serviceIds.push({ uuid: service.uuid, id: service.id });
     }
   }
   // TODO: result 24 => device not connected
 
-  this.emit('servicesDiscover', deviceUuid, serviceUuids);
+  this.emit('servicesDiscover', deviceUuid, serviceIds);
 });
 
-nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(deviceUuid, serviceId, serviceUuids) {
   var args = {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -270,33 +271,32 @@ nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, servi
 nobleBindings.on('kCBMsgId62', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
-  var includedServiceUuids = [];
+  var includedServiceIds = [];
 
   this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
+      id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
 
-    includedServiceUuids.push(includedService.uuid);
+    includedServiceIds.push({ uuid: includedService.uuid, id: includedService.id });
   }
 
-  this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', deviceUuid, serviceStartHandle, includedServiceIds);
 });
 
-nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(deviceUuid, serviceId, characteristicUuids) {
   var args = {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -312,7 +312,6 @@ nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, charac
 nobleBindings.on('kCBMsgId63', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
@@ -322,6 +321,7 @@ nobleBindings.on('kCBMsgId63', function(args) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
 
     var characteristic = {
+      id: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       uuid: args.kCBMsgArgCharacteristics[i].kCBMsgArgUUID.toString('hex'),
       handle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       valueHandle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicValueHandle,
@@ -360,24 +360,24 @@ nobleBindings.on('kCBMsgId63', function(args) {
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
       this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
 
     characteristics.push({
+      id: characteristic.id,
       uuid: characteristic.uuid,
       properties: characteristic.properties
     });
   }
 
-  this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', deviceUuid, serviceStartHandle, characteristics);
 });
 
-nobleBindings.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(deviceUuid, serviceId, characteristicId) {
   this.sendCBMsg(64 , {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -394,8 +394,8 @@ nobleBindings.on('kCBMsgId70', function(args) {
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', deviceUuid, peripheral.services[i].uuid,
-          peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
+        this.emit('read', deviceUuid, peripheral.services[i].id,
+          peripheral.services[i].characteristics[characteristicHandle].id, data, isNotification);
         break;
       }
     }
@@ -404,17 +404,17 @@ nobleBindings.on('kCBMsgId70', function(args) {
   }
 });
 
-nobleBindings.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(deviceUuid, serviceId, characteristicId, data, withoutResponse) {
   this.sendCBMsg(65, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
+    this.emit('write', deviceUuid, serviceId, characteristicId);
   }
 };
 
@@ -426,18 +426,18 @@ nobleBindings.on('kCBMsgId71', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid);
+      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id);
       break;
     }
   }
 });
 
-nobleBindings.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(deviceUuid, serviceId, characteristicId, broadcast) {
   this.sendCBMsg(66, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
@@ -451,18 +451,18 @@ nobleBindings.on('kCBMsgId72', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
 });
 
-nobleBindings.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(deviceUuid, serviceId, characteristicId, notify) {
   this.sendCBMsg(67, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
@@ -476,18 +476,18 @@ nobleBindings.on('kCBMsgId73', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
 });
 
-nobleBindings.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(deviceUuid, serviceId, characteristicId) {
   this.sendCBMsg(69, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -505,27 +505,27 @@ nobleBindings.on('kCBMsgId75', function(args) {
 
       for(var j = 0; j < args.kCBMsgArgDescriptors.length; j++) {
         var descriptor = {
+          id: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle,
           uuid: args.kCBMsgArgDescriptors[j].kCBMsgArgUUID.toString('hex'),
           handle: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle
         };
 
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
-          this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
 
-        descriptors.push(descriptor.uuid);
+        descriptors.push({ uuid: descriptor.uuid, id: descriptor.id });
       }
 
-      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, descriptors);
+      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, descriptors);
       break;
     }
   }
 });
 
-nobleBindings.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(deviceUuid, serviceId, characteristicId, descriptorId) {
   this.sendCBMsg(76, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle
   });
 };
 
@@ -542,19 +542,19 @@ nobleBindings.on('kCBMsgId78', function(args) {
       if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
         this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
+        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].id, data);
         return; // break;
       }
     }
   }
 });
 
-nobleBindings.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(deviceUuid, serviceId, characteristicId, descriptorId, data) {
   this.sendCBMsg(77, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle,
     kCBMsgArgData: data
   });
 };
@@ -571,9 +571,9 @@ nobleBindings.on('kCBMsgId79', function(args) {
       if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
         this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
+        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].id);
         return; // break;
       }
     }

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -315,26 +315,27 @@ nobleBindings.discoverServices = function(deviceUuid, uuids) {
  */
 nobleBindings.on('kCBMsgId56', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
-  var serviceUuids = [];
+  var serviceIds = [];
 
   this._peripherals[deviceUuid].services = {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
       var service = {
+        id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      this._peripherals[deviceUuid].services[service.startHandle] = service;
 
-      serviceUuids.push(service.uuid);
+      serviceIds.push({ uuid: service.uuid, id: service.id });
     }
   }
   // TODO: result 24 => device not connected
 
-  this.emit('servicesDiscover', deviceUuid, serviceUuids);
+  this.emit('servicesDiscover', deviceUuid, serviceIds);
 });
 
 
@@ -348,11 +349,11 @@ nobleBindings.on('kCBMsgId56', function(args) {
  *
  * @dicussion tested
  */
-nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, serviceUuids) {
+nobleBindings.discoverIncludedServices = function(deviceUuid, serviceId, serviceUuids) {
   var args = {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -373,26 +374,25 @@ nobleBindings.discoverIncludedServices = function(deviceUuid, serviceUuid, servi
 nobleBindings.on('kCBMsgId63', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
-  var includedServiceUuids = [];
+  var includedServiceIds = [];
 
   this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
+      id: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
 
-    includedServiceUuids.push(includedService.uuid);
+    includedServiceIds.push({ uuid: includedService.uuid, id: includedService.id });
   }
 
-  this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+  this.emit('includedServicesDiscover', deviceUuid, serviceStartHandle, includedServiceIds);
 });
 
 
@@ -406,11 +406,11 @@ nobleBindings.on('kCBMsgId63', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, characteristicUuids) {
+nobleBindings.discoverCharacteristics = function(deviceUuid, serviceId, characteristicUuids) {
   var args = {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceUuid].startHandle,
-    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceUuid].endHandle,
+    kCBMsgArgServiceStartHandle: this._peripherals[deviceUuid].services[serviceId].startHandle,
+    kCBMsgArgServiceEndHandle: this._peripherals[deviceUuid].services[serviceId].endHandle,
     kCBMsgArgUUIDs: []
   };
 
@@ -431,7 +431,6 @@ nobleBindings.discoverCharacteristics = function(deviceUuid, serviceUuid, charac
 nobleBindings.on('kCBMsgId64', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceStartHandle = args.kCBMsgArgServiceStartHandle;
-  var serviceUuid = this._peripherals[deviceUuid].services[serviceStartHandle].uuid;
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
@@ -441,6 +440,7 @@ nobleBindings.on('kCBMsgId64', function(args) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;
 
     var characteristic = {
+      id: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       uuid: args.kCBMsgArgCharacteristics[i].kCBMsgArgUUID.toString('hex'),
       handle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicHandle,
       valueHandle: args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicValueHandle,
@@ -479,17 +479,17 @@ nobleBindings.on('kCBMsgId64', function(args) {
       characteristic.properties.push('extendedProperties');
     }
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.handle] =
       this._peripherals[deviceUuid].services[serviceStartHandle].characteristics[characteristic.valueHandle] = characteristic;
 
     characteristics.push({
+      id: characteristic.id,
       uuid: characteristic.uuid,
       properties: characteristic.properties
     });
   }
 
-  this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+  this.emit('characteristicsDiscover', deviceUuid, serviceStartHandle, characteristics);
 });
 
 
@@ -503,11 +503,11 @@ nobleBindings.on('kCBMsgId64', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.read = function(deviceUuid, serviceId, characteristicId) {
   this.sendCBMsg(65 , {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -529,8 +529,8 @@ nobleBindings.on('kCBMsgId71', function(args) {
       if (peripheral.services[i].characteristics &&
           peripheral.services[i].characteristics[characteristicHandle]) {
 
-        this.emit('read', deviceUuid, peripheral.services[i].uuid,
-          peripheral.services[i].characteristics[characteristicHandle].uuid, data, isNotification);
+        this.emit('read', deviceUuid, peripheral.services[i].id,
+          peripheral.services[i].characteristics[characteristicHandle].id, data, isNotification);
         break;
       }
     }
@@ -551,17 +551,17 @@ nobleBindings.on('kCBMsgId71', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.write = function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+nobleBindings.write = function(deviceUuid, serviceId, characteristicId, data, withoutResponse) {
   this.sendCBMsg(66, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgData: data,
     kCBMsgArgType: (withoutResponse ? 1 : 0)
   });
 
   if (withoutResponse) {
-    this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
+    this.emit('write', deviceUuid, serviceId, characteristicId);
   }
 };
 
@@ -578,8 +578,8 @@ nobleBindings.on('kCBMsgId72', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid);
+      this.emit('write', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id);
       break;
     }
   }
@@ -598,11 +598,11 @@ nobleBindings.on('kCBMsgId72', function(args) {
  *
  * @discussion The ids were incemented but there seems to be no CoreBluetooth function to call/verify this.
  */
-nobleBindings.broadcast = function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+nobleBindings.broadcast = function(deviceUuid, serviceId, characteristicId, broadcast) {
   this.sendCBMsg(67, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (broadcast ? 1 : 0)
   });
 };
@@ -621,8 +621,8 @@ nobleBindings.on('kCBMsgId73', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('broadcast', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
@@ -640,11 +640,11 @@ nobleBindings.on('kCBMsgId73', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+nobleBindings.notify = function(deviceUuid, serviceId, characteristicId, notify) {
   this.sendCBMsg(68, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle,
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle,
     kCBMsgArgState: (notify ? 1 : 0)
   });
 };
@@ -663,8 +663,8 @@ nobleBindings.on('kCBMsgId74', function(args) {
   for(var i in this._peripherals[deviceUuid].services) {
     if (this._peripherals[deviceUuid].services[i].characteristics &&
         this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle]) {
-      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, state);
+      this.emit('notify', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, state);
       break;
     }
   }
@@ -681,11 +681,11 @@ nobleBindings.on('kCBMsgId74', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.discoverDescriptors = function(deviceUuid, serviceUuid, characteristicUuid) {
+nobleBindings.discoverDescriptors = function(deviceUuid, serviceId, characteristicId) {
   this.sendCBMsg(70, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].handle,
-    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].valueHandle
+    kCBMsgArgCharacteristicHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].handle,
+    kCBMsgArgCharacteristicValueHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].valueHandle
   });
 };
 
@@ -708,18 +708,18 @@ nobleBindings.on('kCBMsgId76', function(args) {
 
       for(var j = 0; j < args.kCBMsgArgDescriptors.length; j++) {
         var descriptor = {
+          id: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle,
           uuid: args.kCBMsgArgDescriptors[j].kCBMsgArgUUID.toString('hex'),
           handle: args.kCBMsgArgDescriptors[j].kCBMsgArgDescriptorHandle
         };
 
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.uuid] =
-          this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].descriptors[descriptor.handle] = descriptor;
 
-        descriptors.push(descriptor.uuid);
+        descriptors.push({ uuid: descriptor.uuid, id: descriptor.id });
       }
 
-      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].uuid, descriptors);
+      this.emit('descriptorsDiscover', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+        this._peripherals[deviceUuid].services[i].characteristics[characteristicHandle].id, descriptors);
       break;
     }
   }
@@ -737,10 +737,10 @@ nobleBindings.on('kCBMsgId76', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.readValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+nobleBindings.readValue = function(deviceUuid, serviceId, characteristicId, descriptorId) {
   this.sendCBMsg(77, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle
+    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle
   });
 };
 
@@ -762,9 +762,9 @@ nobleBindings.on('kCBMsgId79', function(args) {
       if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
         this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid, data);
+        this.emit('valueRead', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].id, data);
         return; // break;
       }
     }
@@ -784,10 +784,10 @@ nobleBindings.on('kCBMsgId79', function(args) {
  *
  * @discussion tested
  */
-nobleBindings.writeValue = function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+nobleBindings.writeValue = function(deviceUuid, serviceId, characteristicId, descriptorId, data) {
   this.sendCBMsg(78, {
     kCBMsgArgDeviceUUID: this._peripherals[deviceUuid].uuid,
-    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceUuid].characteristics[characteristicUuid].descriptors[descriptorUuid].handle,
+    kCBMsgArgDescriptorHandle: this._peripherals[deviceUuid].services[serviceId].characteristics[characteristicId].descriptors[descriptorId].handle,
     kCBMsgArgData: data
   });
 };
@@ -809,9 +809,9 @@ nobleBindings.on('kCBMsgId80', function(args) {
       if (this._peripherals[deviceUuid].services[i].characteristics[j].descriptors &&
         this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle]) {
 
-        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].uuid,
-          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].uuid);
+        this.emit('valueWrite', deviceUuid, this._peripherals[deviceUuid].services[i].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].id,
+          this._peripherals[deviceUuid].services[i].characteristics[j].descriptors[descriptorHandle].id);
         return; // break;
       }
     }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -195,12 +195,12 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
     var services = [];
 
     for (var i = 0; i < serviceUuids.length; i++) {
-      var serviceUuid = serviceUuids[i];
-      var service = new Service(this, peripheralUuid, serviceUuid);
+      var serviceIds = serviceUuids[i];
+      var service = new Service(this, peripheralUuid, serviceIds.id, serviceIds.uuid);
 
-      this._services[peripheralUuid][serviceUuid] = service;
-      this._characteristics[peripheralUuid][serviceUuid] = {};
-      this._descriptors[peripheralUuid][serviceUuid] = {};
+      this._services[peripheralUuid][serviceIds.id] = service;
+      this._characteristics[peripheralUuid][serviceIds.id] = {};
+      this._descriptors[peripheralUuid][serviceIds.id] = {};
 
       services.push(service);
     }
@@ -213,12 +213,12 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
   }
 };
 
-Noble.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
-  this._bindings.discoverIncludedServices(peripheralUuid, serviceUuid, serviceUuids);
+Noble.prototype.discoverIncludedServices = function(peripheralUuid, serviceId, serviceUuids) {
+  this._bindings.discoverIncludedServices(peripheralUuid, serviceId, serviceUuids);
 };
 
-Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUuid, includedServiceUuids) {
-  var service = this._services[peripheralUuid][serviceUuid];
+Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceId, includedServiceUuids) {
+  var service = this._services[peripheralUuid][serviceId];
 
   if (service) {
     service.includedServiceUuids = includedServiceUuids;
@@ -229,29 +229,31 @@ Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUui
   }
 };
 
-Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
-  this._bindings.discoverCharacteristics(peripheralUuid, serviceUuid, characteristicUuids);
+Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceId, characteristicUuids) {
+  this._bindings.discoverCharacteristics(peripheralUuid, serviceId, characteristicUuids);
 };
 
-Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid, characteristics) {
-  var service = this._services[peripheralUuid][serviceUuid];
+Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceId, characteristics) {
+  var service = this._services[peripheralUuid][serviceId];
 
   if (service) {
     var characteristics_ = [];
 
     for (var i = 0; i < characteristics.length; i++) {
-      var characteristicUuid = characteristics[i].uuid;
+      var characteristicId = characteristics[i].id;
 
       var characteristic = new Characteristic(
                                 this,
                                 peripheralUuid,
-                                serviceUuid,
-                                characteristicUuid,
+                                serviceId,
+                                service.uuid,
+                                characteristicId,
+                                characteristics[i].uuid,
                                 characteristics[i].properties
                             );
 
-      this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
+      this._characteristics[peripheralUuid][serviceId][characteristicId] = characteristic;
+      this._descriptors[peripheralUuid][serviceId][characteristicId] = {};
 
       characteristics_.push(characteristic);
     }
@@ -260,90 +262,93 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
 
     service.emit('characteristicsDiscover', characteristics_);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' characteristics discover!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ' characteristics discover!');
   }
 };
 
-Noble.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
-   this._bindings.read(peripheralUuid, serviceUuid, characteristicUuid);
+Noble.prototype.read = function(peripheralUuid, serviceId, characteristicId) {
+   this._bindings.read(peripheralUuid, serviceId, characteristicId);
 };
 
-Noble.prototype.onRead = function(peripheralUuid, serviceUuid, characteristicUuid, data, isNotification) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onRead = function(peripheralUuid, serviceId, characteristicId, data, isNotification) {
+  var characteristic = this._characteristics[peripheralUuid][serviceId][characteristicId];
 
   if (characteristic) {
     characteristic.emit('data', data, isNotification);
 
     characteristic.emit('read', data, isNotification); // for backwards compatbility
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' read!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ' read!');
   }
 };
 
-Noble.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-   this._bindings.write(peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse);
+Noble.prototype.write = function(peripheralUuid, serviceId, characteristicId, data, withoutResponse) {
+   this._bindings.write(peripheralUuid, serviceId, characteristicId, data, withoutResponse);
 };
 
-Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onWrite = function(peripheralUuid, serviceId, characteristicId) {
+  var characteristic = this._characteristics[peripheralUuid][serviceId][characteristicId];
 
   if (characteristic) {
     characteristic.emit('write');
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' write!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ' write!');
   }
 };
 
-Noble.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
-   this._bindings.broadcast(peripheralUuid, serviceUuid, characteristicUuid, broadcast);
+Noble.prototype.broadcast = function(peripheralUuid, serviceId, characteristicId, broadcast) {
+   this._bindings.broadcast(peripheralUuid, serviceId, characteristicId, broadcast);
 };
 
-Noble.prototype.onBroadcast = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onBroadcast = function(peripheralUuid, serviceId, characteristicId, state) {
+  var characteristic = this._characteristics[peripheralUuid][serviceId][characteristicId];
 
   if (characteristic) {
     characteristic.emit('broadcast', state);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' broadcast!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ' broadcast!');
   }
 };
 
-Noble.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUuid, notify) {
-   this._bindings.notify(peripheralUuid, serviceUuid, characteristicUuid, notify);
+Noble.prototype.notify = function(peripheralUuid, serviceId, characteristicId, notify) {
+   this._bindings.notify(peripheralUuid, serviceId, characteristicId, notify);
 };
 
-Noble.prototype.onNotify = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onNotify = function(peripheralUuid, serviceId, characteristicId, state) {
+  var characteristic = this._characteristics[peripheralUuid][serviceId][characteristicId];
 
   if (characteristic) {
     characteristic.emit('notify', state);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ' notify!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ' notify!');
   }
 };
 
-Noble.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  this._bindings.discoverDescriptors(peripheralUuid, serviceUuid, characteristicUuid);
+Noble.prototype.discoverDescriptors = function(peripheralUuid, serviceId, characteristicId) {
+  this._bindings.discoverDescriptors(peripheralUuid, serviceId, characteristicId);
 };
 
-Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, characteristicUuid, descriptors) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceId, characteristicId, descriptors) {
+  var characteristic = this._characteristics[peripheralUuid][serviceId][characteristicId];
 
   if (characteristic) {
     var descriptors_ = [];
 
     for (var i = 0; i < descriptors.length; i++) {
-      var descriptorUuid = descriptors[i];
+      var descriptorId = descriptors[i].id;
 
       var descriptor = new Descriptor(
                             this,
                             peripheralUuid,
-                            serviceUuid,
-                            characteristicUuid,
-                            descriptorUuid
+                            serviceId,
+                            characteristic._serviceUuid,
+                            characteristicId,
+                            characteristic.uuid,
+                            descriptorId,
+                            descriptors[i].uuid
                         );
 
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+      this._descriptors[peripheralUuid][serviceId][characteristicId][descriptorId] = descriptor;
 
       descriptors_.push(descriptor);
     }
@@ -356,31 +361,31 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
   }
 };
 
-Noble.prototype.readValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  this._bindings.readValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+Noble.prototype.readValue = function(peripheralUuid, serviceId, characteristicId, descriptorId) {
+  this._bindings.readValue(peripheralUuid, serviceId, characteristicId, descriptorId);
 };
 
-Noble.prototype.onValueRead = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+Noble.prototype.onValueRead = function(peripheralUuid, serviceId, characteristicId, descriptorId, data) {
+  var descriptor = this._descriptors[peripheralUuid][serviceId][characteristicId][descriptorId];
 
   if (descriptor) {
     descriptor.emit('valueRead', data);
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value read!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ', ' + descriptorId + ' value read!');
   }
 };
 
-Noble.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  this._bindings.writeValue(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+Noble.prototype.writeValue = function(peripheralUuid, serviceId, characteristicId, descriptorId, data) {
+  this._bindings.writeValue(peripheralUuid, serviceId, characteristicId, descriptorId, data);
 };
 
-Noble.prototype.onValueWrite = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+Noble.prototype.onValueWrite = function(peripheralUuid, serviceId, characteristicId, descriptorId) {
+  var descriptor = this._descriptors[peripheralUuid][serviceId][characteristicId][descriptorId];
 
   if (descriptor) {
     descriptor.emit('valueWrite');
   } else {
-    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ', ' + characteristicUuid + ', ' + descriptorUuid + ' value write!');
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceId + ', ' + characteristicId + ', ' + descriptorId + ' value write!');
   }
 };
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -5,10 +5,11 @@ var util = require('util');
 
 var services = require('./services.json');
 
-function Service(noble, peripheralId, uuid) {
+function Service(noble, peripheralId, id, uuid) {
   this._noble = noble;
   this._peripheralId = peripheralId;
 
+  this.id = id;
   this.uuid = uuid;
   this.name = null;
   this.type = null;
@@ -26,6 +27,7 @@ util.inherits(Service, events.EventEmitter);
 
 Service.prototype.toString = function() {
   return JSON.stringify({
+    id: this.id,
     uuid: this.uuid,
     name: this.name,
     type: this.type,
@@ -42,7 +44,7 @@ Service.prototype.discoverIncludedServices = function(serviceUuids, callback) {
 
   this._noble.discoverIncludedServices(
     this._peripheralId,
-    this.uuid,
+    this.id,
     serviceUuids
   );
 };
@@ -56,7 +58,7 @@ Service.prototype.discoverCharacteristics = function(characteristicUuids, callba
 
   this._noble.discoverCharacteristics(
     this._peripheralId,
-    this.uuid,
+    this.id,
     characteristicUuids
   );
 };

--- a/lib/websocket/bindings.js
+++ b/lib/websocket/bindings.js
@@ -53,15 +53,15 @@ NobleBindings.prototype._onMessage = function(event) {
   var advertisement = event.advertisement;
   var rssi = event.rssi;
   var serviceUuids = event.serviceUuids;
-  var serviceUuid = event.serviceUuid;
+  var serviceId = event.serviceId;
   var includedServiceUuids = event.includedServiceUuids;
   var characteristics = event.characteristics;
-  var characteristicUuid = event.characteristicUuid;
+  var characteristicId = event.characteristicId;
   var data = event.data ? new Buffer(event.data, 'hex') : null;
   var isNotification = event.isNotification;
   var state = event.state;
   var descriptors = event.descriptors;
-  var descriptorUuid = event.descriptorUuid;
+  var descriptorId = event.descriptorId;
   var handle = event.handle;
 
   if (type === 'stateChange') {

--- a/test/test-characteristic.js
+++ b/test/test-characteristic.js
@@ -6,7 +6,9 @@ var Characteristic = require('../lib/characteristic');
 describe('Characteristic', function() {
   var mockNoble = null;
   var mockPeripheralId = 'mock-peripheral-id';
+  var mockServiceId = 'mock-service-id';
   var mockServiceUuid = 'mock-service-uuid';
+  var mockId = 'mock-id';
   var mockUuid = 'mock-uuid';
   var mockProperties = ['mock-property-1', 'mock-property-2'];
 
@@ -21,7 +23,7 @@ describe('Characteristic', function() {
       discoverDescriptors: sinon.spy()
     };
 
-    characteristic = new Characteristic(mockNoble, mockPeripheralId, mockServiceUuid, mockUuid, mockProperties);
+    characteristic = new Characteristic(mockNoble, mockPeripheralId, mockServiceId, mockServiceUuid, mockId, mockUuid, mockProperties);
   });
 
   afterEach(function() {
@@ -33,7 +35,7 @@ describe('Characteristic', function() {
   });
 
   it('should lookup name and type by uuid', function() {
-    characteristic = new Characteristic(mockNoble, mockPeripheralId, mockServiceUuid, '2a00', mockProperties);
+    characteristic = new Characteristic(mockNoble, mockPeripheralId, mockServiceId, mockServiceUuid, mockId, '2a00', mockProperties);
 
     characteristic.name.should.equal('Device Name');
     characteristic.type.should.equal('org.bluetooth.characteristic.gap.device_name');
@@ -45,7 +47,7 @@ describe('Characteristic', function() {
 
   describe('toString', function() {
     it('should be uuid, name, type, properties', function() {
-      characteristic.toString().should.equal('{"uuid":"mock-uuid","name":null,"type":null,"properties":["mock-property-1","mock-property-2"]}');
+      characteristic.toString().should.equal('{"id":"mock-id","uuid":"mock-uuid","name":null,"type":null,"properties":["mock-property-1","mock-property-2"]}');
     });
   });
 
@@ -53,7 +55,7 @@ describe('Characteristic', function() {
     it('should delegate to noble', function() {
       characteristic.read();
 
-      mockNoble.read.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid).should.equal(true);
+      mockNoble.read.calledWithExactly(mockPeripheralId, mockServiceId, mockId).should.equal(true);
     });
 
     it('should callback', function() {
@@ -98,13 +100,13 @@ describe('Characteristic', function() {
     it('should delegate to noble, withoutResponse false', function() {
       characteristic.write(mockData, false);
 
-      mockNoble.write.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, mockData, false).should.equal(true);
+      mockNoble.write.calledWithExactly(mockPeripheralId, mockServiceId, mockId, mockData, false).should.equal(true);
     });
 
     it('should delegate to noble, withoutResponse true', function() {
       characteristic.write(mockData, true);
 
-      mockNoble.write.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, mockData, true).should.equal(true);
+      mockNoble.write.calledWithExactly(mockPeripheralId, mockServiceId, mockId, mockData, true).should.equal(true);
     });
 
     it('should callback', function() {
@@ -123,13 +125,13 @@ describe('Characteristic', function() {
     it('should delegate to noble, true', function() {
       characteristic.broadcast(true);
 
-      mockNoble.broadcast.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, true).should.equal(true);
+      mockNoble.broadcast.calledWithExactly(mockPeripheralId, mockServiceId, mockId, true).should.equal(true);
     });
 
     it('should delegate to noble, false', function() {
       characteristic.broadcast(false);
 
-      mockNoble.broadcast.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
+      mockNoble.broadcast.calledWithExactly(mockPeripheralId, mockServiceId, mockId, false).should.equal(true);
     });
 
     it('should callback', function() {
@@ -148,13 +150,13 @@ describe('Characteristic', function() {
     it('should delegate to noble, true', function() {
       characteristic.notify(true);
 
-      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, true).should.equal(true);
+      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceId, mockId, true).should.equal(true);
     });
 
     it('should delegate to noble, false', function() {
       characteristic.notify(false);
 
-      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
+      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceId, mockId, false).should.equal(true);
     });
 
     it('should callback', function() {
@@ -173,7 +175,7 @@ describe('Characteristic', function() {
     it('should delegate to noble notify, true', function() {
       characteristic.subscribe();
 
-      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, true).should.equal(true);
+      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceId, mockId, true).should.equal(true);
     });
 
     it('should callback', function() {
@@ -192,7 +194,7 @@ describe('Characteristic', function() {
     it('should delegate to noble notify, false', function() {
       characteristic.unsubscribe();
 
-      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
+      mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceId, mockId, false).should.equal(true);
     });
 
     it('should callback', function() {
@@ -211,7 +213,7 @@ describe('Characteristic', function() {
     it('should delegate to noble', function() {
       characteristic.discoverDescriptors();
 
-      mockNoble.discoverDescriptors.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid).should.equal(true);
+      mockNoble.discoverDescriptors.calledWithExactly(mockPeripheralId, mockServiceId, mockId).should.equal(true);
     });
 
     it('should callback', function() {

--- a/test/test-descriptor.js
+++ b/test/test-descriptor.js
@@ -6,8 +6,11 @@ var Descriptor = require('../lib/descriptor');
 describe('Descriptor', function() {
   var mockNoble = null;
   var mockPeripheralId = 'mock-peripheral-id';
+  var mockServiceId = 'mock-service-id';
   var mockServiceUuid = 'mock-service-uuid';
   var mockCharacteristicUuid = 'mock-characteristic-uuid';
+  var mockCharacteristicId = 'mock-characteristic-id';
+  var mockId = 'mock-id';
   var mockUuid = 'mock-uuid';
 
   var descriptor = null;
@@ -18,7 +21,7 @@ describe('Descriptor', function() {
       writeValue: sinon.spy()
     };
 
-    descriptor = new Descriptor(mockNoble, mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, mockUuid);
+    descriptor = new Descriptor(mockNoble, mockPeripheralId, mockServiceId, mockServiceUuid, mockCharacteristicId, mockCharacteristicUuid, mockId, mockUuid);
   });
 
   afterEach(function() {
@@ -30,7 +33,7 @@ describe('Descriptor', function() {
   });
 
   it('should lookup name and type by uuid', function() {
-    descriptor = new Descriptor(mockNoble, mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, '2900');
+    descriptor = new Descriptor(mockNoble, mockPeripheralId, mockServiceId, mockServiceUuid, mockCharacteristicId, mockCharacteristicUuid, mockId, '2900');
 
     descriptor.name.should.equal('Characteristic Extended Properties');
     descriptor.type.should.equal('org.bluetooth.descriptor.gatt.characteristic_extended_properties');
@@ -38,7 +41,7 @@ describe('Descriptor', function() {
 
   describe('toString', function() {
     it('should be uuid, name, type', function() {
-      descriptor.toString().should.equal('{"uuid":"mock-uuid","name":null,"type":null}');
+      descriptor.toString().should.equal('{"id":"mock-id","uuid":"mock-uuid","name":null,"type":null}');
     });
   });
 
@@ -46,7 +49,7 @@ describe('Descriptor', function() {
     it('should delegate to noble', function() {
       descriptor.readValue();
 
-      mockNoble.readValue.calledWithExactly(mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, mockUuid).should.equal(true);
+      mockNoble.readValue.calledWithExactly(mockPeripheralId, mockServiceId, mockCharacteristicId, mockId).should.equal(true);
     });
 
     it('should callback', function() {
@@ -103,7 +106,7 @@ describe('Descriptor', function() {
     it('should delegate to noble', function() {
       descriptor.writeValue(mockData);
 
-      mockNoble.writeValue.calledWithExactly(mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, mockUuid, mockData).should.equal(true);
+      mockNoble.writeValue.calledWithExactly(mockPeripheralId, mockServiceId, mockCharacteristicId, mockId,  mockData).should.equal(true);
     });
 
     it('should callback', function() {

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -6,6 +6,7 @@ var Service = require('../lib/service');
 describe('service', function() {
   var mockNoble = null;
   var mockPeripheralId = 'mock-peripheral-id';
+  var mockId= 'mock-id';
   var mockUuid = 'mock-uuid';
 
   var service = null;
@@ -16,7 +17,7 @@ describe('service', function() {
       discoverCharacteristics: sinon.spy()
     };
 
-    service = new Service(mockNoble, mockPeripheralId, mockUuid);
+    service = new Service(mockNoble, mockPeripheralId, mockId, mockUuid);
   });
 
   afterEach(function() {
@@ -28,7 +29,7 @@ describe('service', function() {
   });
 
   it('should lookup name and type by uuid', function() {
-    service = new Service(mockNoble, mockPeripheralId, '1800');
+    service = new Service(mockNoble, mockPeripheralId, mockId, '1800');
 
     service.name.should.equal('Generic Access');
     service.type.should.equal('org.bluetooth.service.generic_access');
@@ -36,7 +37,7 @@ describe('service', function() {
 
   describe('toString', function() {
     it('should be uuid, name, type, includedServiceUuids', function() {
-      service.toString().should.equal('{"uuid":"mock-uuid","name":null,"type":null,"includedServiceUuids":null}');
+      service.toString().should.equal('{"id":"mock-id","uuid":"mock-uuid","name":null,"type":null,"includedServiceUuids":null}');
     });
   });
 
@@ -44,7 +45,7 @@ describe('service', function() {
     it('should delegate to noble', function() {
       service.discoverIncludedServices();
 
-      mockNoble.discoverIncludedServices.calledWithExactly(mockPeripheralId, mockUuid, undefined).should.equal(true);
+      mockNoble.discoverIncludedServices.calledWithExactly(mockPeripheralId, mockId, undefined).should.equal(true);
     });
 
     it('should delegate to noble, with uuids', function() {
@@ -52,7 +53,7 @@ describe('service', function() {
 
       service.discoverIncludedServices(mockUuids);
 
-      mockNoble.discoverIncludedServices.calledWithExactly(mockPeripheralId, mockUuid, mockUuids).should.equal(true);
+      mockNoble.discoverIncludedServices.calledWithExactly(mockPeripheralId, mockId, mockUuids).should.equal(true);
     });
 
     it('should callback', function() {
@@ -83,7 +84,7 @@ describe('service', function() {
     it('should delegate to noble', function() {
       service.discoverCharacteristics();
 
-      mockNoble.discoverCharacteristics.calledWithExactly(mockPeripheralId, mockUuid, undefined).should.equal(true);
+      mockNoble.discoverCharacteristics.calledWithExactly(mockPeripheralId, mockId, undefined).should.equal(true);
     });
 
     it('should delegate to noble, with uuids', function() {
@@ -91,7 +92,7 @@ describe('service', function() {
 
       service.discoverCharacteristics(mockUuids);
 
-      mockNoble.discoverCharacteristics.calledWithExactly(mockPeripheralId, mockUuid, mockUuids).should.equal(true);
+      mockNoble.discoverCharacteristics.calledWithExactly(mockPeripheralId, mockId, mockUuids).should.equal(true);
     });
 
     it('should callback', function() {


### PR DESCRIPTION
This patch is initial work to fix #175 

The main idea is to replace our UUID lookups with ids that are generated locally, so that if a service, characteristic, or descriptor shares a UUID, noble won't overwrite the service repeatedly.

I've only started with the HCI bindings, and will turn my eye to all of the others once @sandeepmistry gives me the nod that this method will satisfy all concerns of his.

I think the PR is simple enough, but let me know if there are any concerns.