### PR TITLE
more work for lazy bindings

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -10,9 +10,9 @@ var Descriptor = require('./descriptor');
 
 function Noble(bindings) {
   this.initialized = false;
-  this.state = 'unknown';
-  this.address = 'unknown';
 
+  this.address = 'unknown';
+  this._state = 'unknown';
   this._bindings = bindings;
   this._peripherals = {};
   this._services = {};
@@ -48,12 +48,27 @@ function Noble(bindings) {
     }
   }.bind(this));
 
+  //lazy init bindings on first new listener, should be on stateChange
   this.on('newListener', function(event) {
     if (event === 'stateChange' && !this.initialized) {
       this._bindings.init();
       this.initialized = true;
     }
   }.bind(this));
+
+  //or lazy init bindings if someone attempts to get state first
+  Object.defineProperties(this, {
+    state: {
+      get: function () {
+        if (!this.initialized) {
+          this._bindings.init();
+          this.initialized = true;
+        }
+        return this._state;
+      }
+    }
+  });
+
 }
 
 util.inherits(Noble, events.EventEmitter);
@@ -61,7 +76,7 @@ util.inherits(Noble, events.EventEmitter);
 Noble.prototype.onStateChange = function(state) {
   debug('stateChange ' + state);
 
-  this.state = state;
+  this._state = state;
 
   this.emit('stateChange', state);
 };
@@ -73,25 +88,36 @@ Noble.prototype.onAddressChange = function(address) {
 };
 
 Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback) {
-  if (this.state !== 'poweredOn') {
-    var error = new Error('Could not start scanning, state is ' + this.state + ' (not poweredOn)');
+  var scan = function(state) {
+    if (state !== 'poweredOn') {
+      var error = new Error('Could not start scanning, state is ' + state + ' (not poweredOn)');
 
-    if (typeof callback === 'function') {
-      callback(error);
+      if (typeof callback === 'function') {
+        callback(error);
+      } else {
+        throw error;
+      }
     } else {
-      throw error;
-    }
-  } else {
-    if (callback) {
-      this.once('scanStart', function(filterDuplicates) {
-        callback(null, filterDuplicates);
-      });
-    }
+      if (callback) {
+        this.once('scanStart', function(filterDuplicates) {
+          callback(null, filterDuplicates);
+        });
+      }
 
-    this._discoveredPeripheralUUids = [];
-    this._allowDuplicates = allowDuplicates;
+      this._discoveredPeripheralUUids = [];
+      this._allowDuplicates = allowDuplicates;
 
-    this._bindings.startScanning(serviceUuids, allowDuplicates);
+      this._bindings.startScanning(serviceUuids, allowDuplicates);
+    }
+  };
+
+  //if bindings still not init, do it now
+  if (!this.initialized) {
+    this._bindings.init();
+    this.initialized = true;
+    this.once('stateChange', go.bind(this));
+  }else{
+    scan.call(this, this._state);
   }
 };
 
@@ -104,7 +130,9 @@ Noble.prototype.stopScanning = function(callback) {
   if (callback) {
     this.once('scanStop', callback);
   }
-  this._bindings.stopScanning();
+  if(this._bindings && this.initialized){
+    this._bindings.stopScanning();
+  }
 };
 
 Noble.prototype.onScanStop = function() {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -115,7 +115,7 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
   if (!this.initialized) {
     this._bindings.init();
     this.initialized = true;
-    this.once('stateChange', go.bind(this));
+    this.once('stateChange', scan.bind(this));
   }else{
     scan.call(this, this._state);
   }


### PR DESCRIPTION
We merged the last change, but Im already seeing some oddness with folks who use the startscanning without waiting for (or even creating a listener on) statechange thus not having bindings init. Thinking about it more, someone might also be polling noble.state and would never init bindings either.

The only other public facing api is noble.stopScan but thats easier, if were not init, just dont call the bindings layer.