### PR TITLE
Use noble-uwp bindings when possible

### DIFF
--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -9,8 +9,20 @@ module.exports = function() {
     return require('./distributed/bindings');
   } else if (platform === 'darwin') {
     return require('./mac/bindings');
-  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32') {
+  } else if (platform === 'linux' || platform === 'freebsd') {
     return require('./hci-socket/bindings');
+  } else if (platform === 'win32') {
+    // Noble UWP bindings require Node >= 6 and Windows >= 10.0.15063.
+    var nodeVer = process.versions.node.split('.').map(Number);
+    var osVer = os.release().split('.').map(Number);
+    if ((nodeVer[0] >= 6) &&
+        ((osVer[0] > 10) ||
+         (osVer[0] === 10 && osVer[1] > 0) ||
+         (osVer[0] === 10 && osVer[1] === 0 && osVer[2] >= 15063))) {
+        return require('noble-uwp/lib/bindings');
+    } else {
+      return require('./hci-socket/bindings');
+    }
   } else {
     throw new Error('Unsupported platform');
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "optionalDependencies": {
     "bluetooth-hci-socket": "^0.5.1",
     "bplist-parser": "0.0.6",
+    "noble-uwp": "^0.4.3",
     "xpc-connection": "~0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
 - Add an optional package dependency on noble-uwp.
 - When resolving bindings, select noble-uwp if the OS is Windows >= 10.0.10563 and Node version is >= 6. Otherwise fall back to the hci-socket bindings as before.

Fixes: https://github.com/sandeepmistry/noble/issues/550