### PR TITLE
added connection canceling to hci lib

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -45,6 +45,7 @@ var OCF_LE_SET_EVENT_MASK = 0x0001;
 var OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
 var OCF_LE_SET_SCAN_ENABLE = 0x000c;
 var OCF_LE_CREATE_CONN = 0x000d;
+var OCF_LE_CANCEL_CONN = 0x000e;
 var OCF_LE_CONN_UPDATE = 0x0013;
 var OCF_LE_START_ENCRYPTION = 0x0019;
 
@@ -65,6 +66,7 @@ var LE_SET_SCAN_PARAMETERS_CMD = OCF_LE_SET_SCAN_PARAMETERS | OGF_LE_CTL << 10;
 var LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | OGF_LE_CTL << 10;
 var LE_CREATE_CONN_CMD = OCF_LE_CREATE_CONN | OGF_LE_CTL << 10;
 var LE_CONN_UPDATE_CMD = OCF_LE_CONN_UPDATE | OGF_LE_CTL << 10;
+var LE_CANCEL_CONN_CMD = OCF_LE_CANCEL_CONN | OGF_LE_CTL << 10;
 var LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | OGF_LE_CTL << 10;
 
 var HCI_OE_USER_ENDED_CONNECTION = 0x13;
@@ -343,6 +345,20 @@ Hci.prototype.connUpdateLe = function(handle, minInterval, maxInterval, latency,
 
   debug('conn update le - writing: ' + cmd.toString('hex'));
   this._socket.write(cmd);
+};
+
+Hci.prototype.cancelConnect = function() {
+   var cmd = new Buffer(4);
+
+   // header
+   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+   cmd.writeUInt16LE(LE_CANCEL_CONN_CMD, 1);
+
+   // length
+   cmd.writeUInt8(0x0, 3);
+
+   debug('cancel le conn - writing: ' + cmd.toString('hex'));
+   this._socket.write(cmd);
 };
 
 Hci.prototype.startLeEncryption = function(handle, random, diversifier, key) {


### PR DESCRIPTION
add the ability to cancel connection attempts.

P.S.:
I am using the hci-socket lib directly thats why I just added it there. Wouldn't it be nice to split out the bindings so you can use them directly if you want to go a bit more low level but not the whole way through ;-)