### PR TITLE
gatt - add offset to buffer write for 0.10 type error fixes

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -285,7 +285,7 @@ Gatt.prototype.writeRequest = function(handle, data, withoutResponse) {
 Gatt.prototype.prepareWriteRequest = function(handle, offset, data) {
   var buf = new Buffer(5 + data.length);
 
-  buf.writeUInt8(ATT_OP_PREPARE_WRITE_REQ);
+  buf.writeUInt8(ATT_OP_PREPARE_WRITE_REQ, 0);
   buf.writeUInt16LE(handle, 1);
   buf.writeUInt16LE(offset, 3);
 
@@ -299,7 +299,7 @@ Gatt.prototype.prepareWriteRequest = function(handle, offset, data) {
 Gatt.prototype.executeWriteRequest = function(handle, cancelPreparedWrites) {
   var buf = new Buffer(2);
 
-  buf.writeUInt8(ATT_OP_EXECUTE_WRITE_REQ);
+  buf.writeUInt8(ATT_OP_EXECUTE_WRITE_REQ, 0);
   buf.writeUInt8(cancelPreparedWrites ? 0 : 1, 1);
 
   return buf;

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -525,13 +525,13 @@ Gatt.prototype.read = function(serviceUuid, characteristicUuid) {
 Gatt.prototype.write = function(serviceUuid, characteristicUuid, data, withoutResponse) {
   var characteristic = this._characteristics[serviceUuid][characteristicUuid];
 
-  if (withoutResponse) {
+  if (data.length + 3 > this._mtu) {
+    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
+  } else if (withoutResponse) {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, true), null, function() {
       this.emit('write', this._address, serviceUuid, characteristicUuid);
     }.bind(this));
-  } else if (data.length + 3 > this._mtu) {
-    return this.longWrite(serviceUuid, characteristicUuid, data, withoutResponse);
-  } else {
+  }  else {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, false), function(data) {
       var opcode = data[0];
 


### PR DESCRIPTION
In node 0.10, the lack of the offset argument causes the following error.

```bash
TypeError: offset is not uint
    at TypeError (<anonymous>)
    at checkInt (buffer.js:786:11)
    at Buffer.writeUInt8 (buffer.js:794:5)
    at Gatt.executeWriteRequest (/root/Computrols/ble-manager/node_modules/noble/lib/hci-socket/gatt.js:302:7)
    at Gatt.longWrite (/root/Computrols/ble-manager/node_modules/noble/lib/hci-socket/gatt.js:578:27)
    at Gatt.write (/root/Computrols/ble-manager/node_modules/noble/lib/hci-socket/gatt.js:533:17)
    at NobleBindings.write (/root/Computrols/ble-manager/node_modules/noble/lib/hci-socket/bindings.js:364:10)
    at Noble.write (/root/Computrols/ble-manager/node_modules/noble/lib/noble.js:284:19)
    at Characteristic.write (/root/Computrols/ble-manager/node_modules/noble/lib/characteristic.js:74:15)
```

//cc @sandeepmistry @jacobrosenthal 