### PR TITLE
fix ADV_SCAN_IND considered connectable

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -6,6 +6,28 @@ var util = require('util');
 
 var isChip = (os.platform() === 'linux') && (os.release().indexOf('-ntc') !== -1);
 
+var EVENT_TYPE_ADV_IND =          0x00; // connectable, non-direceted, scannable
+var EVENT_TYPE_ADV_DIRECT_IND =   0x01; // connectable, directed, non-scannable
+var EVENT_TYPE_ADV_SCAN_IND =     0x02; // non-connectable, non-directed, scannable
+var EVENT_TYPE_ADV_NONCONN_IND =  0x03; // non-connectable, non-directed, non-scannable
+var EVENT_TYPE_SCAN_RESPONSE =    0x04; // scan response
+
+var isNonConnectableEventTypefunction = function(type) {
+	return type === EVENT_TYPE_ADV_SCAN_IND || type === EVENT_TYPE_ADV_NONCONN_IND;
+};
+
+var isConnectableEventType = function(type) {
+	return type === EVENT_TYPE_ADV_IND || type === EVENT_TYPE_ADV_DIRECT_IND;
+};
+
+var isScannableEventType = function(type) {
+	return type === EVENT_TYPE_ADV_IND || type === EVENT_TYPE_ADV_SCAN_IND;
+};
+
+var isNonScannableEventType = function(type) {
+	return type === EVENT_TYPE_ADV_DIRECT_IND || type === EVENT_TYPE_ADV_NONCONN_IND;
+};
+
 var Gap = function(hci) {
   this._hci = hci;
 
@@ -109,7 +131,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
   var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
   var hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
 
-  if (type === 0x04) {
+  if (type === EVENT_TYPE_SCAN_RESPONSE) {
     hasScanResponse = true;
   } else {
     // reset service data every non-scan response event
@@ -239,7 +261,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
+  var connectable = (type === EVENT_TYPE_SCAN_RESPONSE && previouslyDiscovered) ? this._discoveries[address].connectable : isConnectableEventType(type);
 
   this._discoveries[address] = {
     address: address,
@@ -251,8 +273,8 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     hasScanResponse: hasScanResponse
   };
 
-  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
-  if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
+  // only report after a scan response event or more than one discovery without a scan response, so more data can be collected
+  if ( isNonScannableEventType(type) || type === EVENT_TYPE_SCAN_RESPONSE || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
     this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
   }
 };


### PR DESCRIPTION
ADV_SCAN_IND is not connectable.

Created named constants to and eventType evaluation functions to clarify the meaning of the eventTypes.

See Bluetooth Core Spec, section 7.7.65.2