### PR TITLE
Memory leak fix

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -6,7 +6,7 @@ var util = require('util');
 
 var isChip = (os.platform() === 'linux') && (os.release().indexOf('-ntc') !== -1);
 
-// Event types: See Bluetooth Core Spec, section 7.7.65.2
+// LE Advertising Report Event types: See Bluetooth Core Spec, section 7.7.65.2
 var EVENT_TYPE_ADV_IND =          0x00; // connectable, non-direceted, scannable
 var EVENT_TYPE_ADV_DIRECT_IND =   0x01; // connectable, directed, non-scannable
 var EVENT_TYPE_ADV_SCAN_IND =     0x02; // non-connectable, non-directed, scannable

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -224,7 +224,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04) ? undefined : type !== 0x03;
+  var connectable = (type === 0x04) ? undefined : (type !== 0x03);
 
   this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
 

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -11,7 +11,6 @@ var Gap = function(hci) {
 
   this._scanState = null;
   this._scanFilterDuplicates = null;
-  this._discoveries = {};
 
   this._hci.on('error', this.onHciError.bind(this));
   this._hci.on('leScanParametersSet', this.onHciLeScanParametersSet.bind(this));
@@ -26,7 +25,6 @@ util.inherits(Gap, events.EventEmitter);
 Gap.prototype.startScanning = function(allowDuplicates) {
   this._scanState = 'starting';
   this._scanFilterDuplicates = !allowDuplicates;
-  this._discoveries = {};
 
   // Always set scan parameters before scanning
   // https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=229737
@@ -97,8 +95,8 @@ Gap.prototype.onLeScanEnableSetCmd = function(enable, filterDuplicates) {
 };
 
 Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, addressType, eir, rssi) {
-  var previouslyDiscovered = !process.env.NOBLE_REPORT_ALL_HCI_EVENTS && !!this._discoveries[address];
-  var advertisement =  previouslyDiscovered ? this._discoveries[address].advertisement : {
+  var advertisement =  {
+    isScanResponse: type === 0x04,
     localName: undefined,
     txPowerLevel: undefined,
     manufacturerData: undefined,
@@ -106,24 +104,6 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     serviceUuids: [],
     solicitationServiceUuids: []
   };
-
-  if(process.env.NOBLE_REPORT_ALL_HCI_EVENTS){
-    advertisement.type = type;
-  }
-
-  var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
-  var hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
-
-  if (type === 0x04) {
-    hasScanResponse = true;
-  } else {
-    // reset service data every non-scan response event
-    advertisement.serviceData = [];
-    advertisement.serviceUuids = [];
-    advertisement.serviceSolicitationUuids = [];
-  }
-
-  discoveryCount++;
 
   var i = 0;
   var j = 0;
@@ -244,24 +224,10 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03 && type !== 0x04);
+  var connectable = (type === 0x04) ? undefined : type !== 0x03;
 
-  if (!process.env.NOBLE_REPORT_ALL_HCI_EVENTS){
-    this._discoveries[address] = {
-      address: address,
-      addressType: addressType,
-      connectable: connectable,
-      advertisement: advertisement,
-      rssi: rssi,
-      count: discoveryCount,
-      hasScanResponse: hasScanResponse
-    };
-  }
+  this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
 
-  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
-  if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
-    this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
-  }
 };
 
 module.exports = Gap;

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -26,6 +26,7 @@ util.inherits(Gap, events.EventEmitter);
 Gap.prototype.startScanning = function(allowDuplicates) {
   this._scanState = 'starting';
   this._scanFilterDuplicates = !allowDuplicates;
+  this._discoveries = {};
 
   // Always set scan parameters before scanning
   // https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=229737
@@ -96,7 +97,7 @@ Gap.prototype.onLeScanEnableSetCmd = function(enable, filterDuplicates) {
 };
 
 Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, addressType, eir, rssi) {
-  var previouslyDiscovered = !!this._discoveries[address];
+  var previouslyDiscovered = !process.env.NOBLE_REPORT_ALL_HCI_EVENTS && !!this._discoveries[address];
   var advertisement =  previouslyDiscovered ? this._discoveries[address].advertisement : {
     localName: undefined,
     txPowerLevel: undefined,
@@ -105,6 +106,10 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     serviceUuids: [],
     solicitationServiceUuids: []
   };
+
+  if(process.env.NOBLE_REPORT_ALL_HCI_EVENTS){
+    advertisement.type = type;
+  }
 
   var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
   var hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
@@ -239,17 +244,19 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
+  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03 && type !== 0x04);
 
-  this._discoveries[address] = {
-    address: address,
-    addressType: addressType,
-    connectable: connectable,
-    advertisement: advertisement,
-    rssi: rssi,
-    count: discoveryCount,
-    hasScanResponse: hasScanResponse
-  };
+  if (!process.env.NOBLE_REPORT_ALL_HCI_EVENTS){
+    this._discoveries[address] = {
+      address: address,
+      addressType: addressType,
+      connectable: connectable,
+      advertisement: advertisement,
+      rssi: rssi,
+      count: discoveryCount,
+      hasScanResponse: hasScanResponse
+    };
+  }
 
   // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
   if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -6,6 +6,13 @@ var util = require('util');
 
 var isChip = (os.platform() === 'linux') && (os.release().indexOf('-ntc') !== -1);
 
+// Event types: See Bluetooth Core Spec, section 7.7.65.2
+var EVENT_TYPE_ADV_IND =          0x00; // connectable, non-direceted, scannable
+var EVENT_TYPE_ADV_DIRECT_IND =   0x01; // connectable, directed, non-scannable
+var EVENT_TYPE_ADV_SCAN_IND =     0x02; // non-connectable, non-directed, scannable
+var EVENT_TYPE_ADV_NONCONN_IND =  0x03; // non-connectable, non-directed, non-scannable
+var EVENT_TYPE_SCAN_RESPONSE =    0x04; // scan response
+
 var Gap = function(hci) {
   this._hci = hci;
 
@@ -96,7 +103,7 @@ Gap.prototype.onLeScanEnableSetCmd = function(enable, filterDuplicates) {
 
 Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, addressType, eir, rssi) {
   var advertisement =  {
-    isScanResponse: type === 0x04,
+    isScanResponse: type === EVENT_TYPE_SCAN_RESPONSE,
     localName: undefined,
     txPowerLevel: undefined,
     manufacturerData: undefined,
@@ -224,7 +231,7 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-  var connectable = (type === 0x04) ? undefined : (type !== 0x03);
+  var connectable = (type === EVENT_TYPE_SCAN_RESPONSE) ? undefined : (type === EVENT_TYPE_ADV_IND || type === EVENT_TYPE_ADV_DIRECT_IND);
 
   this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -10,7 +10,11 @@ var Descriptor = require('./descriptor');
 
 var PeripheralCache = require("./peripheralCache");
 
-var DEFAULT_MAX_CACHE_AGE = 5000;
+// The max cache age sets the minimum time we will cache device information in the peripheral cache.
+// The BLE maximum advertising interval is 10.24s + 10ms random delay,
+// and broadcasts cycle through 3 channels, so the maximum full cycle is 30.75s.
+// This default is slightly longer than two full cycles. 
+var DEFAULT_MAX_CACHE_AGE = 62000;
 
 function Noble(bindings) {
   this.initialized = false;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -157,33 +157,45 @@ Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, a
 
   if (!peripheral) {
     peripheral = new Peripheral(this, uuid, address, addressType, connectable, advertisement, rssi);
-    peripheral.mergedAdvertisementData = advertisement;
+    peripheral._hasScanResponse = advertisement.isScanResponse;
+    peripheral._discovered = false;
     this._peripheralCache.addPeripheral(peripheral);
   } else {
-    //update the last advertisement
-    peripheral.advertisement = advertisement;
-    peripheral.connectable = (advertisement.type === 0x04) ? peripheral.connectable || connectable : connectable;
+    //update the peripheral state
+    if (connectable !== undefined){
+      peripheral.connectable = connectable;
+    }
+    if (advertisement.isScanResponse){
+      peripheral._hasScanResponse = true;
+    }
 
     //merge the advertisement state
     for (var i in advertisement) {
       if (i != "serviceData" && advertisement[i] !== undefined) {
-        peripheral.mergedAdvertisementData[i] = advertisement[i];
+        peripheral.advertisement[i] = advertisement[i];
       }
     }
     //replace any service data entries this advertisement contains
     var updatedServiceDataUuids = {};
     advertisement.serviceData.map(function(entry){ return entry.uuid; }).forEach(function(uuid){ updatedServiceDataUuids[uuid] = true; });
-    peripheral.mergedAdvertisementData.serviceData = peripheral.mergedAdvertisementData.serviceData.filter(function(entry){ 
+    peripheral.advertisement.serviceData = peripheral.advertisement.serviceData.filter(function(entry){ 
       return !updatedServiceDataUuids[entry.uuid]; 
     }).concat(advertisement.serviceData);
-
 
     peripheral.rssi = rssi;
     previouslyDiscovered = true;
   }
 
-  if (this._allowDuplicates || !previouslyDiscovered) {
-    this.emit('discover', peripheral);
+  //if using HCI, only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
+  var reportThisEvent = advertisement.isScanResponse === undefined || // not from hci
+    process.env.NOBLE_REPORT_ALL_HCI_EVENTS ||
+    advertisement.isScanResponse ||
+    !connectable ||
+    (previouslyDiscovered && !peripheral._hasScanResponse);
+
+  if (reportThisEvent && (this._allowDuplicates || !peripheral._discovered)) {
+    this.emit('discover', peripheral, advertisement);
+    peripheral._discovered = true;
   }
 };
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -105,10 +105,10 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
       }
 
       this._allowDuplicates = allowDuplicates;
+      if(this._peripheralCache){
+        this._peripheralCache.stopSweeping();
+      }
       if(allowDuplicates){
-        if(this._peripheralCache){
-          this._peripheralCache.stopSweeping();
-        }
         this._peripheralCache = new PeripheralCache(DEFAULT_MAX_CACHE_AGE);
         this._peripheralCache.startSweeping();
       }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -157,14 +157,26 @@ Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, a
 
   if (!peripheral) {
     peripheral = new Peripheral(this, uuid, address, addressType, connectable, advertisement, rssi);
+    peripheral.mergedAdvertisementData = advertisement;
     this._peripheralCache.addPeripheral(peripheral);
   } else {
-    // "or" the advertisment data with existing
+    //update the last advertisement
+    peripheral.advertisement = advertisement;
+    peripheral.connectable = (advertisement.type === 0x04) ? peripheral.connectable || connectable : connectable;
+
+    //merge the advertisement state
     for (var i in advertisement) {
-      if (advertisement[i] !== undefined) {
-        peripheral.advertisement[i] = advertisement[i];
+      if (i != "serviceData" && advertisement[i] !== undefined) {
+        peripheral.mergedAdvertisementData[i] = advertisement[i];
       }
     }
+    //replace any service data entries this advertisement contains
+    var updatedServiceDataUuids = {};
+    advertisement.serviceData.map(function(entry){ return entry.uuid; }).forEach(function(uuid){ updatedServiceDataUuids[uuid] = true; });
+    peripheral.mergedAdvertisementData.serviceData = peripheral.mergedAdvertisementData.serviceData.filter(function(entry){ 
+      return !updatedServiceDataUuids[entry.uuid]; 
+    }).concat(advertisement.serviceData);
+
 
     peripheral.rssi = rssi;
     previouslyDiscovered = true;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -231,7 +231,7 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
       var serviceUuid = serviceUuids[i];
       var service = new Service(this, peripheralUuid, serviceUuid);
 
-      this._peripheralCache.addService(peripheralUuid, serviceUuid, service);
+      this._peripheralCache.addService(peripheralUuid, service);
 
       services.push(service);
     }
@@ -281,7 +281,7 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
                                 characteristics[i].properties
                             );
 
-      this._peripheralCache.addCharacteristic(peripheralUuid, serviceUuid, characteristicUuid, characteristic);
+      this._peripheralCache.addCharacteristic(peripheralUuid, serviceUuid, characteristic);
 
       characteristics_.push(characteristic);
     }
@@ -373,7 +373,7 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
                             descriptorUuid
                         );
 
-      this._peripheralCache.addDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, descriptor);
+      this._peripheralCache.addDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptor);
 
       descriptors_.push(descriptor);
     }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -8,17 +8,17 @@ var Service = require('./service');
 var Characteristic = require('./characteristic');
 var Descriptor = require('./descriptor');
 
+var PeripheralCache = require("./peripheralCache");
+
+var DEFAULT_MAX_CACHE_AGE = 5000;
+
 function Noble(bindings) {
   this.initialized = false;
 
   this.address = 'unknown';
   this._state = 'unknown';
   this._bindings = bindings;
-  this._peripherals = {};
-  this._services = {};
-  this._characteristics = {};
-  this._descriptors = {};
-  this._discoveredPeripheralUUids = [];
+  this._peripheralCache = new PeripheralCache();
 
   this._bindings.on('stateChange', this.onStateChange.bind(this));
   this._bindings.on('addressChange', this.onAddressChange.bind(this));
@@ -104,8 +104,14 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
         });
       }
 
-      this._discoveredPeripheralUUids = [];
       this._allowDuplicates = allowDuplicates;
+      if(allowDuplicates){
+        if(this._peripheralCache){
+          this._peripheralCache.stopSweeping();
+        }
+        this._peripheralCache = new PeripheralCache(DEFAULT_MAX_CACHE_AGE);
+        this._peripheralCache.startSweeping();
+      }
 
       this._bindings.startScanning(serviceUuids, allowDuplicates);
     }
@@ -133,6 +139,7 @@ Noble.prototype.stopScanning = function(callback) {
   if(this._bindings && this.initialized){
     this._bindings.stopScanning();
   }
+  this._peripheralCache.stopSweeping();
 };
 
 Noble.prototype.onScanStop = function() {
@@ -141,15 +148,12 @@ Noble.prototype.onScanStop = function() {
 };
 
 Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, advertisement, rssi) {
-  var peripheral = this._peripherals[uuid];
+  var peripheral = this._peripheralCache.getPeripheral(uuid);
+  var previouslyDiscovered = false;
 
   if (!peripheral) {
     peripheral = new Peripheral(this, uuid, address, addressType, connectable, advertisement, rssi);
-
-    this._peripherals[uuid] = peripheral;
-    this._services[uuid] = {};
-    this._characteristics[uuid] = {};
-    this._descriptors[uuid] = {};
+    this._peripheralCache.addPeripheral(peripheral);
   } else {
     // "or" the advertisment data with existing
     for (var i in advertisement) {
@@ -159,15 +163,10 @@ Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, a
     }
 
     peripheral.rssi = rssi;
+    previouslyDiscovered = true;
   }
 
-  var previouslyDiscoverd = (this._discoveredPeripheralUUids.indexOf(uuid) !== -1);
-
-  if (!previouslyDiscoverd) {
-    this._discoveredPeripheralUUids.push(uuid);
-  }
-
-  if (this._allowDuplicates || !previouslyDiscoverd) {
+  if (this._allowDuplicates || !previouslyDiscovered) {
     this.emit('discover', peripheral);
   }
 };
@@ -177,7 +176,7 @@ Noble.prototype.connect = function(peripheralUuid) {
 };
 
 Noble.prototype.onConnect = function(peripheralUuid, error) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.state = error ? 'error' : 'connected';
@@ -192,7 +191,7 @@ Noble.prototype.disconnect = function(peripheralUuid) {
 };
 
 Noble.prototype.onDisconnect = function(peripheralUuid) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.state = 'disconnected';
@@ -207,7 +206,7 @@ Noble.prototype.updateRssi = function(peripheralUuid) {
 };
 
 Noble.prototype.onRssiUpdate = function(peripheralUuid, rssi) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.rssi = rssi;
@@ -223,7 +222,7 @@ Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
 };
 
 Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     var services = [];
@@ -232,9 +231,7 @@ Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
       var serviceUuid = serviceUuids[i];
       var service = new Service(this, peripheralUuid, serviceUuid);
 
-      this._services[peripheralUuid][serviceUuid] = service;
-      this._characteristics[peripheralUuid][serviceUuid] = {};
-      this._descriptors[peripheralUuid][serviceUuid] = {};
+      this._peripheralCache.addService(peripheralUuid, serviceUuid, service);
 
       services.push(service);
     }
@@ -252,7 +249,7 @@ Noble.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid,
 };
 
 Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUuid, includedServiceUuids) {
-  var service = this._services[peripheralUuid][serviceUuid];
+  var service = this._peripheralCache.getService(peripheralUuid, serviceUuid);
 
   if (service) {
     service.includedServiceUuids = includedServiceUuids;
@@ -268,7 +265,7 @@ Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, 
 };
 
 Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid, characteristics) {
-  var service = this._services[peripheralUuid][serviceUuid];
+  var service = this._peripheralCache.getService(peripheralUuid, serviceUuid);
 
   if (service) {
     var characteristics_ = [];
@@ -284,8 +281,7 @@ Noble.prototype.onCharacteristicsDiscover = function(peripheralUuid, serviceUuid
                                 characteristics[i].properties
                             );
 
-      this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
+      this._peripheralCache.addCharacteristic(peripheralUuid, serviceUuid, characteristicUuid, characteristic);
 
       characteristics_.push(characteristic);
     }
@@ -303,7 +299,7 @@ Noble.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid)
 };
 
 Noble.prototype.onRead = function(peripheralUuid, serviceUuid, characteristicUuid, data, isNotification) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+  var characteristic = this._peripheralCache.getCharacteristic(peripheralUuid, serviceUuid, characteristicUuid);
 
   if (characteristic) {
     characteristic.emit('data', data, isNotification);
@@ -319,7 +315,7 @@ Noble.prototype.write = function(peripheralUuid, serviceUuid, characteristicUuid
 };
 
 Noble.prototype.onWrite = function(peripheralUuid, serviceUuid, characteristicUuid) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+  var characteristic = this._peripheralCache.getCharacteristic(peripheralUuid, serviceUuid, characteristicUuid);
 
   if (characteristic) {
     characteristic.emit('write');
@@ -333,7 +329,7 @@ Noble.prototype.broadcast = function(peripheralUuid, serviceUuid, characteristic
 };
 
 Noble.prototype.onBroadcast = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+  var characteristic = this._peripheralCache.getCharacteristic(peripheralUuid, serviceUuid, characteristicUuid);
 
   if (characteristic) {
     characteristic.emit('broadcast', state);
@@ -347,7 +343,7 @@ Noble.prototype.notify = function(peripheralUuid, serviceUuid, characteristicUui
 };
 
 Noble.prototype.onNotify = function(peripheralUuid, serviceUuid, characteristicUuid, state) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+  var characteristic = this._peripheralCache.getCharacteristic(peripheralUuid, serviceUuid, characteristicUuid);
 
   if (characteristic) {
     characteristic.emit('notify', state);
@@ -361,7 +357,7 @@ Noble.prototype.discoverDescriptors = function(peripheralUuid, serviceUuid, char
 };
 
 Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, characteristicUuid, descriptors) {
-  var characteristic = this._characteristics[peripheralUuid][serviceUuid][characteristicUuid];
+  var characteristic = this._peripheralCache.getCharacteristic(peripheralUuid, serviceUuid, characteristicUuid);
 
   if (characteristic) {
     var descriptors_ = [];
@@ -377,7 +373,7 @@ Noble.prototype.onDescriptorsDiscover = function(peripheralUuid, serviceUuid, ch
                             descriptorUuid
                         );
 
-      this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+      this._peripheralCache.addDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, descriptor);
 
       descriptors_.push(descriptor);
     }
@@ -395,7 +391,7 @@ Noble.prototype.readValue = function(peripheralUuid, serviceUuid, characteristic
 };
 
 Noble.prototype.onValueRead = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+  var descriptor = this._peripheralCache.getDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
 
   if (descriptor) {
     descriptor.emit('valueRead', data);
@@ -409,7 +405,7 @@ Noble.prototype.writeValue = function(peripheralUuid, serviceUuid, characteristi
 };
 
 Noble.prototype.onValueWrite = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-  var descriptor = this._descriptors[peripheralUuid][serviceUuid][characteristicUuid][descriptorUuid];
+  var descriptor = this._peripheralCache.getDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
 
   if (descriptor) {
     descriptor.emit('valueWrite');
@@ -423,7 +419,7 @@ Noble.prototype.readHandle = function(peripheralUuid, handle) {
 };
 
 Noble.prototype.onHandleRead = function(peripheralUuid, handle, data) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.emit('handleRead' + handle, data);
@@ -437,7 +433,7 @@ Noble.prototype.writeHandle = function(peripheralUuid, handle, data, withoutResp
 };
 
 Noble.prototype.onHandleWrite = function(peripheralUuid, handle) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.emit('handleWrite' + handle);
@@ -447,7 +443,7 @@ Noble.prototype.onHandleWrite = function(peripheralUuid, handle) {
 };
 
 Noble.prototype.onHandleNotify = function(peripheralUuid, handle, data) {
-  var peripheral = this._peripherals[peripheralUuid];
+  var peripheral = this._peripheralCache.getPeripheral(peripheralUuid);
 
   if (peripheral) {
     peripheral.emit('handleNotify', handle, data);

--- a/lib/peripheralCache.js
+++ b/lib/peripheralCache.js
@@ -31,7 +31,7 @@ PeripheralCache.prototype.getPeripheral = function(uuid){
   }
 };
 
- PeripheralCache.prototype.getService = function(peripheralUuid, serviceUuid){
+PeripheralCache.prototype.getService = function(peripheralUuid, serviceUuid){
   var entry = this._cache[peripheralUuid];
   if (entry){
     this.touch(peripheralUuid);
@@ -47,7 +47,7 @@ PeripheralCache.prototype.getCharacteristic = function(peripheralUuid, serviceUu
   }
  };
 
- PeripheralCache.prototype.getDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid){
+PeripheralCache.prototype.getDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid){
   var entry = this._cache[peripheralUuid];
   if (entry){
     this.touch(peripheralUuid);
@@ -104,7 +104,7 @@ PeripheralCache.prototype._checkEntries = function(){
   var now = new Date();
   for (var uuid in this._cache){
     var time = this._cache[uuid].updatedTime;
-    if (time < now - this.maxAge && (!this._cache[uuid].peripheral || this._cache[uuid].peripheral.state != "connected")){
+    if ((time < (now - this.maxAge)) && (!this._cache[uuid].peripheral || this._cache[uuid].peripheral.state != "connected")){
         delete this._cache[uuid];
     }
   }

--- a/lib/peripheralCache.js
+++ b/lib/peripheralCache.js
@@ -1,0 +1,129 @@
+function PeripheralCache(maxAge){
+  this._cache = {};
+  this.maxAge = maxAge;
+}
+
+PeripheralCache.prototype.getOrAddEntry = function(uuid){
+  var entry = this._cache[uuid];
+  if (!entry){
+    this._cache[uuid] = {
+      peripheral: undefined,
+      services: {},
+      characteristics: {},
+      descriptors: {},
+      updatedTime: new Date()
+    };
+
+      entry = this._cache[uuid];
+  }
+  return entry;
+};
+
+PeripheralCache.prototype.getEntry = function(uuid){
+  return this._cache[uuid];
+};
+
+PeripheralCache.prototype.getPeripheral = function(uuid){
+  var entry = this._cache[uuid];
+  if (entry){
+    this.touch(uuid);
+    return entry.peripheral;
+  }
+};
+
+ PeripheralCache.prototype.getService = function(peripheralUuid, serviceUuid){
+  var entry = this._cache[peripheralUuid];
+  if (entry){
+    this.touch(peripheralUuid);
+    return entry.services[serviceUuid];
+  }
+ };
+
+PeripheralCache.prototype.getCharacteristic = function(peripheralUuid, serviceUuid, characteristicUuid){
+  var entry = this._cache[peripheralUuid];
+  if (entry){
+    this.touch(peripheralUuid);
+    return entry.characteristics[serviceUuid][characteristicUuid];
+  }
+ };
+
+ PeripheralCache.prototype.getDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid){
+  var entry = this._cache[peripheralUuid];
+  if (entry){
+    this.touch(peripheralUuid);
+    return entry.descriptors[serviceUuid][characteristicUuid][descriptorUuid];
+  }
+ };
+
+PeripheralCache.prototype.addPeripheral = function(uuid, peripheral){
+  var entry = this.getOrAddEntry(uuid);
+  entry.peripheral = peripheral;
+  this.touch(uuid);
+};
+
+PeripheralCache.prototype.addService = function(peripheralUuid, serviceUuid, service){
+  var entry = this.getEntry(peripheralUuid);
+  if (entry){
+    entry.services[serviceUuid] = service;
+    entry.characteristics[serviceUuid] = {};
+    entry.descriptors[serviceUuid] = {};
+    this.touch(peripheralUuid);
+  }
+};
+
+PeripheralCache.prototype.addCharacteristic = function(peripheralUuid, serviceUuid, characteristicUuid, characteristic){
+  var entry = this.getEntry(peripheralUuid);
+  if(entry){
+    entry.characteristics[serviceUuid][characteristicUuid] = characteristic;
+    entry.descriptors[serviceUuid][characteristicUuid] = {};
+    this.touch(peripheralUuid);
+  }
+};
+
+PeripheralCache.prototype.addDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, descriptor){
+  var entry = this.getEntry(peripheralUuid);
+  if(entry){
+    entry.descriptors[serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+    this.touch(peripheralUuid);
+  }
+};
+
+PeripheralCache.prototype.touch = function(uuid){
+  var entry = this.getEntry(uuid);
+  if(entry){
+    entry.updatedTime = new Date();
+  }
+};
+
+PeripheralCache.prototype.contains = function(uuid){
+  var entry = this.getEntry(uuid);
+  return entry !== undefined;
+};
+
+PeripheralCache.prototype._checkEntries = function(){
+  var now = new Date();
+  for (var uuid in this._cache){
+    var time = this._cache[uuid].updatedTime;
+    if (time < now - this.maxAge && (!this._cache[uuid].peripheral || this._cache[uuid].peripheral.state != "connected")){
+        delete this._cache[uuid];
+    }
+  }
+};
+
+PeripheralCache.prototype.startSweeping = function(){
+  this.stopSweeping();
+  if(!this.maxAge){
+    //we can't sweep if there is no maximum age defined
+    return;
+  }
+  this._sweeperInterval = setInterval(this._checkEntries.bind(this), this.maxAge / 2);
+};
+
+PeripheralCache.prototype.stopSweeping = function(){
+  if(this._sweeperInterval){
+    clearInterval(this._sweeperInterval);
+    delete this._sweeperInterval;
+  }
+};
+
+module.exports = PeripheralCache;

--- a/lib/peripheralCache.js
+++ b/lib/peripheralCache.js
@@ -61,29 +61,29 @@ PeripheralCache.prototype.addPeripheral = function(peripheral){
   this.touch(peripheral.uuid);
 };
 
-PeripheralCache.prototype.addService = function(peripheralUuid, serviceUuid, service){
+PeripheralCache.prototype.addService = function(peripheralUuid, service){
   var entry = this.getEntry(peripheralUuid);
   if (entry){
-    entry.services[serviceUuid] = service;
-    entry.characteristics[serviceUuid] = {};
-    entry.descriptors[serviceUuid] = {};
+    entry.services[service.uuid] = service;
+    entry.characteristics[service.uuid] = {};
+    entry.descriptors[service.uuid] = {};
     this.touch(peripheralUuid);
   }
 };
 
-PeripheralCache.prototype.addCharacteristic = function(peripheralUuid, serviceUuid, characteristicUuid, characteristic){
+PeripheralCache.prototype.addCharacteristic = function(peripheralUuid, serviceUuid, characteristic){
   var entry = this.getEntry(peripheralUuid);
   if(entry){
-    entry.characteristics[serviceUuid][characteristicUuid] = characteristic;
-    entry.descriptors[serviceUuid][characteristicUuid] = {};
+    entry.characteristics[serviceUuid][characteristic.uuid] = characteristic;
+    entry.descriptors[serviceUuid][characteristic.uuid] = {};
     this.touch(peripheralUuid);
   }
 };
 
-PeripheralCache.prototype.addDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, descriptor){
+PeripheralCache.prototype.addDescriptor = function(peripheralUuid, serviceUuid, characteristicUuid, descriptor){
   var entry = this.getEntry(peripheralUuid);
   if(entry){
-    entry.descriptors[serviceUuid][characteristicUuid][descriptorUuid] = descriptor;
+    entry.descriptors[serviceUuid][characteristicUuid][descriptor.uuid] = descriptor;
     this.touch(peripheralUuid);
   }
 };

--- a/lib/peripheralCache.js
+++ b/lib/peripheralCache.js
@@ -55,10 +55,10 @@ PeripheralCache.prototype.getCharacteristic = function(peripheralUuid, serviceUu
   }
  };
 
-PeripheralCache.prototype.addPeripheral = function(uuid, peripheral){
-  var entry = this.getOrAddEntry(uuid);
+PeripheralCache.prototype.addPeripheral = function(peripheral){
+  var entry = this.getOrAddEntry(peripheral.uuid);
   entry.peripheral = peripheral;
-  this.touch(uuid);
+  this.touch(peripheral.uuid);
 };
 
 PeripheralCache.prototype.addService = function(peripheralUuid, serviceUuid, service){

--- a/test/test-peripheralCache.js
+++ b/test/test-peripheralCache.js
@@ -79,13 +79,12 @@ describe('PeripheralCache', function(){
     var cache = new PeripheralCache();
 
     var testPeripheral = {uuid:"12345"};
-    var testService = "test service";
-    var testServiceUuid = "67890";
+    var testService = {uuid: "67890"};
 
     cache.addPeripheral(testPeripheral);
-    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
+    cache.addService(testPeripheral.uuid, testService);
 
-    var retrievedService = cache.getService(testPeripheral.uuid, testServiceUuid);
+    var retrievedService = cache.getService(testPeripheral.uuid, testService.uuid);
     retrievedService.should.equal(testService);
   });
 
@@ -93,16 +92,14 @@ describe('PeripheralCache', function(){
     var cache = new PeripheralCache();
 
     var testPeripheral = {uuid:"12345"};
-    var testService = "test service";
-    var testServiceUuid = "67890";
-    var testCharacteristic = "test characteristic";
-    var testCharacteristicUuid = "13579";
+    var testService = {uuid: "67890"};
+    var testCharacteristic = {uuid: "13579"};
 
     cache.addPeripheral(testPeripheral);
-    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
-    cache.addCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
+    cache.addService(testPeripheral.uuid, testService);
+    cache.addCharacteristic(testPeripheral.uuid, testService.uuid, testCharacteristic);
 
-    var retrievedCharacteristic = cache.getCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid);
+    var retrievedCharacteristic = cache.getCharacteristic(testPeripheral.uuid, testService.uuid, testCharacteristic.uuid);
     retrievedCharacteristic.should.equal(testCharacteristic);
   });
 
@@ -110,20 +107,16 @@ describe('PeripheralCache', function(){
     var cache = new PeripheralCache();
 
     var testPeripheral = {uuid:"12345"};
-    var testService = "test service";
-    var testServiceUuid = "67890";
-    var testCharacteristic = "test characteristic";
-    var testCharacteristicUuid = "13579";
-    var testDescriptor = "test desceriptor";
-    var testDescriptorUuid = "24680";
-
+    var testService = {uuid: "67890"};
+    var testCharacteristic = {uuid: "13579"};
+    var testDescriptor = {uuid: "24680"};
 
     cache.addPeripheral(testPeripheral);
-    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
-    cache.addCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
-    cache.addDescriptor(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid, testDescriptor);
+    cache.addService(testPeripheral.uuid, testService);
+    cache.addCharacteristic(testPeripheral.uuid, testService.uuid, testCharacteristic);
+    cache.addDescriptor(testPeripheral.uuid, testService.uuid, testCharacteristic.uuid, testDescriptor);
 
-    var retrievedDescriptor = cache.getDescriptor(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid);
+    var retrievedDescriptor = cache.getDescriptor(testPeripheral.uuid, testService.uuid, testCharacteristic.uuid, testDescriptor.uuid);
     retrievedDescriptor.should.equal(testDescriptor);
   });
 

--- a/test/test-peripheralCache.js
+++ b/test/test-peripheralCache.js
@@ -1,0 +1,136 @@
+var should = require('should');
+
+var PeripheralCache = require("../lib/peripheralCache");
+
+describe('PeripheralCache', function(){
+
+  it('should create an empty cache', function(){
+    var cache = new PeripheralCache();
+    Object.keys(cache._cache).length.should.equal(0);
+    should.not.exist(cache.maxAge);
+  });
+
+  it('should create an empty with maximum age specified', function(){
+    var cache = new PeripheralCache(5000);
+    Object.keys(cache._cache).length.should.equal(0);
+    cache.maxAge.should.equal(5000);
+  });
+
+  it('should store and retrieve peripheral information', function(){
+    var cache = new PeripheralCache(5000);
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+
+    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    retrievedPeripheral.should.equal(testPeripheral);
+    cache.contains(testPeripheralUuid).should.equal(true);
+  });
+
+  it('should return undefined when the peripheral is not in the cache', function(){
+    var cache = new PeripheralCache(5000);
+    var testPeripheralUuid = "12345";
+
+    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    should.not.exist(retrievedPeripheral);
+    cache.contains(testPeripheralUuid).should.equal(false);
+  });
+
+  it('should sweep old peripherals from the cache', function(done){
+    var cache = new PeripheralCache(1);
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+
+    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    retrievedPeripheral.should.equal(testPeripheral);
+    cache.contains(testPeripheralUuid).should.equal(true);
+
+    cache.startSweeping();
+
+    setTimeout(function(){
+      retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+      should.not.exist(retrievedPeripheral);
+      cache.contains(testPeripheralUuid).should.equal(false);
+      cache.stopSweeping();
+      done();
+    }, 3);
+  });
+
+  it('should not sweep old peripherals from the cache when no maximum age was specified', function(done){
+    var cache = new PeripheralCache();
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+
+    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    retrievedPeripheral.should.equal(testPeripheral);
+
+    cache.startSweeping();
+
+    setTimeout(function(){
+      cache.contains(testPeripheralUuid).should.equal(true);
+      cache.stopSweeping();
+      done();
+    }, 3);
+  });
+
+  it('should store and retrieve services', function(){
+    var cache = new PeripheralCache();
+
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+    var testService = "test service";
+    var testServiceUuid = "67890";
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addService(testPeripheralUuid, testServiceUuid, testService);
+
+    var retrievedService = cache.getService(testPeripheralUuid, testServiceUuid);
+    retrievedService.should.equal(testService);
+  });
+
+  it('should store and retrieve characteristics', function(){
+    var cache = new PeripheralCache();
+
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+    var testService = "test service";
+    var testServiceUuid = "67890";
+    var testCharacteristic = "test characteristic";
+    var testCharacteristicUuid = "13579";
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addService(testPeripheralUuid, testServiceUuid, testService);
+    cache.addCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
+
+    var retrievedCharacteristic = cache.getCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid);
+    retrievedCharacteristic.should.equal(testCharacteristic);
+  });
+
+  it('should store and retrieve descriptors', function(){
+    var cache = new PeripheralCache();
+
+    var testPeripheral = "test peripheral";
+    var testPeripheralUuid = "12345";
+    var testService = "test service";
+    var testServiceUuid = "67890";
+    var testCharacteristic = "test characteristic";
+    var testCharacteristicUuid = "13579";
+    var testDescriptor = "test desceriptor";
+    var testDescriptorUuid = "24680";
+
+
+    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addService(testPeripheralUuid, testServiceUuid, testService);
+    cache.addCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
+    cache.addDescriptor(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid, testDescriptor);
+
+    var retrievedDescriptor = cache.getDescriptor(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid);
+    retrievedDescriptor.should.equal(testDescriptor);
+  });
+
+});

--- a/test/test-peripheralCache.js
+++ b/test/test-peripheralCache.js
@@ -18,14 +18,13 @@ describe('PeripheralCache', function(){
 
   it('should store and retrieve peripheral information', function(){
     var cache = new PeripheralCache(5000);
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addPeripheral(testPeripheral);
 
-    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    var retrievedPeripheral = cache.getPeripheral(testPeripheral.uuid);
     retrievedPeripheral.should.equal(testPeripheral);
-    cache.contains(testPeripheralUuid).should.equal(true);
+    cache.contains(testPeripheral.uuid).should.equal(true);
   });
 
   it('should return undefined when the peripheral is not in the cache', function(){
@@ -39,21 +38,20 @@ describe('PeripheralCache', function(){
 
   it('should sweep old peripherals from the cache', function(done){
     var cache = new PeripheralCache(1);
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addPeripheral(testPeripheral);
 
-    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    var retrievedPeripheral = cache.getPeripheral(testPeripheral.uuid);
     retrievedPeripheral.should.equal(testPeripheral);
-    cache.contains(testPeripheralUuid).should.equal(true);
+    cache.contains(testPeripheral.uuid).should.equal(true);
 
     cache.startSweeping();
 
     setTimeout(function(){
-      retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+      retrievedPeripheral = cache.getPeripheral(testPeripheral.uuid);
       should.not.exist(retrievedPeripheral);
-      cache.contains(testPeripheralUuid).should.equal(false);
+      cache.contains(testPeripheral.uuid).should.equal(false);
       cache.stopSweeping();
       done();
     }, 3);
@@ -61,18 +59,17 @@ describe('PeripheralCache', function(){
 
   it('should not sweep old peripherals from the cache when no maximum age was specified', function(done){
     var cache = new PeripheralCache();
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
+    cache.addPeripheral(testPeripheral);
 
-    var retrievedPeripheral = cache.getPeripheral(testPeripheralUuid);
+    var retrievedPeripheral = cache.getPeripheral(testPeripheral.uuid);
     retrievedPeripheral.should.equal(testPeripheral);
 
     cache.startSweeping();
 
     setTimeout(function(){
-      cache.contains(testPeripheralUuid).should.equal(true);
+      cache.contains(testPeripheral.uuid).should.equal(true);
       cache.stopSweeping();
       done();
     }, 3);
@@ -81,41 +78,38 @@ describe('PeripheralCache', function(){
   it('should store and retrieve services', function(){
     var cache = new PeripheralCache();
 
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
     var testService = "test service";
     var testServiceUuid = "67890";
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
-    cache.addService(testPeripheralUuid, testServiceUuid, testService);
+    cache.addPeripheral(testPeripheral);
+    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
 
-    var retrievedService = cache.getService(testPeripheralUuid, testServiceUuid);
+    var retrievedService = cache.getService(testPeripheral.uuid, testServiceUuid);
     retrievedService.should.equal(testService);
   });
 
   it('should store and retrieve characteristics', function(){
     var cache = new PeripheralCache();
 
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
     var testService = "test service";
     var testServiceUuid = "67890";
     var testCharacteristic = "test characteristic";
     var testCharacteristicUuid = "13579";
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
-    cache.addService(testPeripheralUuid, testServiceUuid, testService);
-    cache.addCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
+    cache.addPeripheral(testPeripheral);
+    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
+    cache.addCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
 
-    var retrievedCharacteristic = cache.getCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid);
+    var retrievedCharacteristic = cache.getCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid);
     retrievedCharacteristic.should.equal(testCharacteristic);
   });
 
   it('should store and retrieve descriptors', function(){
     var cache = new PeripheralCache();
 
-    var testPeripheral = "test peripheral";
-    var testPeripheralUuid = "12345";
+    var testPeripheral = {uuid:"12345"};
     var testService = "test service";
     var testServiceUuid = "67890";
     var testCharacteristic = "test characteristic";
@@ -124,12 +118,12 @@ describe('PeripheralCache', function(){
     var testDescriptorUuid = "24680";
 
 
-    cache.addPeripheral(testPeripheralUuid, testPeripheral);
-    cache.addService(testPeripheralUuid, testServiceUuid, testService);
-    cache.addCharacteristic(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
-    cache.addDescriptor(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid, testDescriptor);
+    cache.addPeripheral(testPeripheral);
+    cache.addService(testPeripheral.uuid, testServiceUuid, testService);
+    cache.addCharacteristic(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testCharacteristic);
+    cache.addDescriptor(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid, testDescriptor);
 
-    var retrievedDescriptor = cache.getDescriptor(testPeripheralUuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid);
+    var retrievedDescriptor = cache.getDescriptor(testPeripheral.uuid, testServiceUuid, testCharacteristicUuid, testDescriptorUuid);
     retrievedDescriptor.should.equal(testDescriptor);
   });
 


### PR DESCRIPTION
This pull request fixes several memory leaks that would occur in long-running processes, which were particularly evident in environments with beacons that rotate their unique ids.

This problem was resolved by centralizing the way that Noble caches peripheral information, and periodically sweeping the cache and purging any unconnected peripherals that have not been heard or accessed in a long time.

This caching behavior should only be active when `allowDuplicates` is true.

As a consequence of these changes, some changes had to be made to `onDiscover()`, which now calls with two arguments rather than one. For compatibility with previous behavior, the first argument contains the merged information for all the advertisements that have been heard from that peripheral. The new second argument contains only the information received in the specific advertisement for the event.

This pull request fixes #636 and incidentally also resolves the issues discussed in pr #695.