### PR TITLE
Don't forget previously discovered characteristics

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -410,7 +410,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
   var service = this._services[serviceUuid];
   var characteristics = [];
 
-  this._characteristics[serviceUuid] = {};
+  this._characteristics[serviceUuid] = this._characteristics[serviceUuid] || {};
   this._descriptors[serviceUuid] = this._descriptors[serviceUuid] || {};
 
   var callback = function(data) {

--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -317,7 +317,7 @@ nobleBindings.on('kCBMsgId72', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  this._peripherals[deviceUuid].services = this._peripherals[deviceUuid].services || {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -327,7 +327,9 @@ nobleBindings.on('kCBMsgId72', function(args) {
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      if (!this._peripherals[deviceUuid].services[service.uuid] ) {
+        this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      }
 
       serviceUuids.push(service.uuid);
     }
@@ -377,7 +379,8 @@ nobleBindings.on('kCBMsgId76', function(args) {
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
+  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices =
+    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -386,8 +389,10 @@ nobleBindings.on('kCBMsgId76', function(args) {
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    if (! this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid]) {
+      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
+        this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    }
 
     includedServiceUuids.push(includedService.uuid);
   }
@@ -435,9 +440,8 @@ nobleBindings.on('kCBMsgId77', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
-      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
-  }
+  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics =
+      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics || {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -435,7 +435,9 @@ nobleBindings.on('kCBMsgId77', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+      this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -435,9 +435,9 @@ nobleBindings.on('kCBMsgId77', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
       this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
-
+  }
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -316,8 +316,9 @@ nobleBindings.on('kCBMsgId63', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
     this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  }
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -230,7 +230,7 @@ nobleBindings.on('kCBMsgId55', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  this._peripherals[deviceUuid].services = this._peripherals[deviceUuid].services || {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -274,7 +274,8 @@ nobleBindings.on('kCBMsgId62', function(args) {
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
+  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices =
+    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -283,8 +284,10 @@ nobleBindings.on('kCBMsgId62', function(args) {
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };
 
-    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
-      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    if (! this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid]) {
+      this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.uuid] =
+        this._peripherals[deviceUuid].services[serviceStartHandle].includedServices[includedServices.startHandle] = includedService;
+    }
 
     includedServiceUuids.push(includedService.uuid);
   }
@@ -316,9 +319,8 @@ nobleBindings.on('kCBMsgId63', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
-  }
+  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics =
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics || {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -316,7 +316,8 @@ nobleBindings.on('kCBMsgId63', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -435,8 +435,9 @@ nobleBindings.on('kCBMsgId64', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
     this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  }
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -435,7 +435,8 @@ nobleBindings.on('kCBMsgId64', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
+  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics)
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -317,7 +317,7 @@ nobleBindings.on('kCBMsgId56', function(args) {
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var serviceUuids = [];
 
-  this._peripherals[deviceUuid].services = {};
+  this._peripherals[deviceUuid].services = this._peripherals[deviceUuid].services || {};
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
@@ -327,7 +327,9 @@ nobleBindings.on('kCBMsgId56', function(args) {
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
 
-      this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      if (typeof this._peripherals[deviceUuid].services[service.uuid] == 'undefined') {
+        this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      }  
 
       serviceUuids.push(service.uuid);
     }
@@ -377,7 +379,8 @@ nobleBindings.on('kCBMsgId63', function(args) {
   var result = args.kCBMsgArgResult;
   var includedServiceUuids = [];
 
-  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = {};
+  this._peripherals[deviceUuid].services[serviceStartHandle].includedServices = 
+    this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var includedService = {
@@ -435,9 +438,8 @@ nobleBindings.on('kCBMsgId64', function(args) {
   var result = args.kCBMsgArgResult;
   var characteristics = [];
 
-  if (! this._peripherals[deviceUuid].services[serviceStartHandle].characteristics) {
-    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics = {};
-  }
+  this._peripherals[deviceUuid].services[serviceStartHandle].characteristics =
+    this._peripherals[deviceUuid].services[serviceStartHandle].characteristics || {};
 
   for(var i = 0; i < args.kCBMsgArgCharacteristics.length; i++) {
     var properties = args.kCBMsgArgCharacteristics[i].kCBMsgArgCharacteristicProperties;


### PR DESCRIPTION
... when calling discoverCharacteristics multiple times in a program.

Without this fix, we get crashes when unsubscribing, and never receive 'data' events on previously subscribed characteristics if calling discoverCharacteristics multiple times with different uuid lists.

This PR includes comments/feedback from #730 